### PR TITLE
fix: кнопки fov и освящения в песочнице не отслеживали изменения

### DIFF
--- a/Content.Client/Sandbox/SandboxSystem.cs
+++ b/Content.Client/Sandbox/SandboxSystem.cs
@@ -1,7 +1,9 @@
 using Content.Client.Administration.Managers;
+using Content.Client.Ghost;
 using Content.Client.Movement.Systems;
 using Content.Shared.Sandbox;
 using Robust.Client.Console;
+using Robust.Client.GameObjects;
 using Robust.Client.Placement;
 using Robust.Client.Placement.Modes;
 using Robust.Shared.Map;
@@ -22,10 +24,18 @@ namespace Content.Client.Sandbox
         public event Action? SandboxEnabled;
         public event Action? SandboxDisabled;
 
+        public event Action? LightingToggled;
+        public event Action? FovToggled;
+        public event Action? PlayerAttached;
+
         public override void Initialize()
         {
             _adminManager.AdminStatusUpdated += CheckStatus;
             SubscribeNetworkEvent<MsgSandboxStatus>(OnSandboxStatus);
+
+            SubscribeLocalEvent<ToggleLightingActionEvent>(OnToggleLighting);
+            SubscribeLocalEvent<ToggleFoVActionEvent>(OnToggleFoV);
+            SubscribeLocalEvent<PlayerAttachedEvent>(OnPlayerAttached);
         }
 
         private void CheckStatus()
@@ -59,6 +69,21 @@ namespace Content.Client.Sandbox
         {
             _sandboxEnabled = sandboxEnabled;
             CheckStatus();
+        }
+
+        private void OnPlayerAttached(PlayerAttachedEvent ev)
+        {
+            PlayerAttached?.Invoke();
+        }
+
+        private void OnToggleFoV(ToggleFoVActionEvent ev)
+        {
+            FovToggled?.Invoke();
+        }
+
+        private void OnToggleLighting(ToggleLightingActionEvent ev)
+        {
+            LightingToggled?.Invoke();
         }
 
         public void Respawn()

--- a/Content.Client/UserInterface/Systems/Sandbox/SandboxUIController.cs
+++ b/Content.Client/UserInterface/Systems/Sandbox/SandboxUIController.cs
@@ -1,4 +1,4 @@
-﻿using Content.Client.Administration.Managers;
+using Content.Client.Administration.Managers;
 using Content.Client.Gameplay;
 using Content.Client.Markers;
 using Content.Client.Sandbox;
@@ -116,6 +116,22 @@ public sealed class SandboxUIController : UIController, IOnStateChanged<Gameplay
         _window.MachineLinkingButton.OnPressed += _ => _sandbox.MachineLinking();
     }
 
+    private void UpdateFovButtomState()
+    {
+        if (_window != null)
+        {
+            _window.ToggleFovButton.Pressed = !_eye.CurrentEye.DrawFov;
+        }
+    }
+
+    private void UpdateLightButtomState()
+    {
+        if (_window != null)
+        {
+            _window.ToggleLightButton.Pressed = !_light.Enabled;
+        }
+    }
+
     private void CheckSandboxVisibility()
     {
         if (SandboxButton == null)
@@ -140,6 +156,26 @@ public sealed class SandboxUIController : UIController, IOnStateChanged<Gameplay
         system.SandboxDisabled += CloseAll;
         system.SandboxEnabled += CheckSandboxVisibility;
         system.SandboxDisabled += CheckSandboxVisibility;
+
+        system.PlayerAttached += System_PlayerAttached;
+        system.FovToggled += System_FovToggled;
+        system.LightingToggled += System_LightingToggled;
+    }
+
+    private void System_LightingToggled()
+    {
+        UpdateLightButtomState();
+    }
+
+    private void System_FovToggled()
+    {
+        UpdateFovButtomState();
+    }
+
+    private void System_PlayerAttached()
+    {
+        UpdateFovButtomState();
+        UpdateLightButtomState();
     }
 
     public void OnSystemUnloaded(SandboxSystem system)
@@ -147,6 +183,10 @@ public sealed class SandboxUIController : UIController, IOnStateChanged<Gameplay
         system.SandboxDisabled -= CloseAll;
         system.SandboxEnabled -= CheckSandboxVisibility;
         system.SandboxDisabled -= CheckSandboxVisibility;
+
+        system.PlayerAttached -= System_PlayerAttached;
+        system.FovToggled -= System_FovToggled;
+        system.LightingToggled -= System_LightingToggled;
     }
 
     private void SandboxButtonPressed(ButtonEventArgs args)


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->

Для окна песочницы добавил подписку на событие изменения параметра Fov и освещения, а так же на событие прикрепления игрока с сущности.

Событие Fov и освещения нужно для изменения состояния клавиш, при нажатии на клавиши левой панели в состоянии призрака.

Событие прикрепления позволяет обновлять состояние клавиш при переходе их админгоста к телу.

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->

https://github.com/SerbiaStrong-220/space-station-14/assets/10843461/39af98df-9e6f-4fdd-8fd9-bf2a3e7f8d4c

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->

:cl:
- fix: Кнопки fov и освящения в песочнице не отслеживали игровое изменение данных параметров
