### PR TITLE
Change typing notification behavior for OOC and LOOC chat.

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -175,7 +175,10 @@ public partial class ChatBox : UIWidget
         _controller.UpdateSelectedChannel(this);
 
         // Warn typing indicator about change
-        _controller.NotifyChatTextChange();
+        if ((SelectedChannel & (ChatSelectChannel.OOC | ChatSelectChannel.LOOC)) == 0)
+        {
+            _controller.NotifyChatTextChange();
+        }
     }
 
     // Corvax-TypingIndicator-Start


### PR DESCRIPTION
## Описание PR
Если пользователь пишет в LOOC или OOC чат, не показывать тайпинг бабл над его головой.

**Проверки**
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl: Rincew1nd
- tweak: Отключено отображение набора текста персонажем в LOOC или OOC чат
