### PR TITLE
Round notifications system now sends embeds

### DIFF
--- a/Resources/Locale/ru-RU/corvax/round-notifications/notifications.ftl
+++ b/Resources/Locale/ru-RU/corvax/round-notifications/notifications.ftl
@@ -1,4 +1,5 @@
+discord-round-embed-title = SS14 | { $server }
 discord-round-new = Новый раунд начинается!
-discord-round-start = Раунд #{ $id } на карте "{ $map }" начался.
-discord-round-end = Раунд #{ $id } закончился. Он длился { $hours } ч., { $minutes } мин., и { $seconds } сек.
+discord-round-start = Раунд **#{ $id }** на карте **"{ $map }"** начался.
+discord-round-end = Раунд **#{ $id }** закончился. Он длился **{ $hours } ч., { $minutes } мин., и { $seconds } сек.**
 discord-round-unknown-map = Неизвестна


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->
Вебхук теперь посылает оповещения о начале раундов в виде эмбедов с названием сервера в заголовке. В данный момент используется полное название сервера т.е. например "SS220 Main"

**Медиа**
![image](https://github.com/SerbiaStrong-220/space-station-14/assets/16546901/b4f59f33-a277-4c22-a96d-3d9cff6f1faf)
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->

:cl: TheArturZh
- tweak: Оповещения о начале раундов в дискорде теперь в виде эмбедов