### PR TITLE
Added unlimited technologies to R&D

### DIFF
--- a/Content.Shared/Research/Components/TechnologyDatabaseComponent.cs
+++ b/Content.Shared/Research/Components/TechnologyDatabaseComponent.cs
@@ -27,6 +27,9 @@ public sealed partial class TechnologyDatabaseComponent : Component
     [DataField("supportedDisciplines", customTypeSerializer: typeof(PrototypeIdListSerializer<TechDisciplinePrototype>))]
     public List<string> SupportedDisciplines = new();
 
+    [DataField("allowUnlimitedTechnoligies"), ViewVariables(VVAccess.ReadWrite)]
+    public bool AllowUnlimitedTechnoligies = true;
+
     /// <summary>
     /// The ids of all the technologies which have been unlocked.
     /// </summary>

--- a/Content.Shared/Research/Systems/SharedResearchSystem.cs
+++ b/Content.Shared/Research/Systems/SharedResearchSystem.cs
@@ -132,10 +132,11 @@ public abstract class SharedResearchSystem : EntitySystem
             if (percent < techDiscipline.TierPrerequisites[tier])
                 break;
 
-            if (tier >= techDiscipline.LockoutTier &&
-                component.MainDiscipline != null &&
-                techDiscipline.ID != component.MainDiscipline)
-                break;
+            if(!component.AllowUnlimitedTechnoligies)
+                if (tier >= techDiscipline.LockoutTier &&
+                    component.MainDiscipline != null &&
+                    techDiscipline.ID != component.MainDiscipline)
+                    break;
             tier++;
         }
 


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
На данный момент если РнД изучат одну ветку, к примеру, медицину, блокируются последние тиры других веток (кто это вообще придумал, ужас какой). Надо бы сделать так, чтоб ниче не блокировалось и всё было как в 13.

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: Alan Wake
- add: Добавлено свойство компонента TechnologyDatabaseComponent AllowUnlimitedTechnoligies чтобы не ограничивать  или наоборот ограничивать их в возможности исследования не головных веток. По умолчанию они не ограничены.