### PR TITLE
Revert "Diona Pacifist fix"

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/diona.yml
@@ -30,4 +30,4 @@
     - type: Faction
       factions:
         - NanoTrasen
-    # - type: Pacifist # Corvax-DionaPacifist
+    - type: Pacifist # Corvax-DionaPacifist


### PR DESCRIPTION
Reverts SerbiaStrong-220/space-station-14#96

Потому-что диона не пацифист это не по лору. Если люди на дионе хотят биться то пускай выбирают другую расу.