### PR TITLE
Фикс выдачи обратно руды при разборе печки

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -187,6 +187,8 @@ namespace Content.Server.GameTicking
             DebugTools.AssertNotNull(mobMaybe);
             var mob = mobMaybe!.Value;
 
+            newMind.MainPlayer = true;
+
             _mind.TransferTo(newMind, mob);
 
             if (lateJoin)

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -2,9 +2,11 @@ using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using Content.Server.Ghost;
+using Content.Server.Mind.Components;
 using Content.Server.Players;
 using Content.Server.Spawners.Components;
 using Content.Server.Speech.Components;
+using Content.Server.SS220.TraitorComponentTarget;
 using Content.Server.Station.Components;
 using Content.Shared.Database;
 using Content.Shared.GameTicking;
@@ -187,7 +189,7 @@ namespace Content.Server.GameTicking
             DebugTools.AssertNotNull(mobMaybe);
             var mob = mobMaybe!.Value;
 
-            newMind.MainPlayer = true;
+            EntityManager.AddComponent<TraitorTargetComponent>(mob);
 
             _mind.TransferTo(newMind, mob);
 

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -775,7 +775,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 var newMind = _mindSystem.CreateMind(session.UserId, spawnDetails.Name);
                 _mindSystem.SetUserId(newMind, session.UserId);
                 _mindSystem.AddRole(newMind, new NukeopsRole(newMind, nukeOpsAntag));
-
+                
                 _mindSystem.TransferTo(newMind, mob);
             }
             else if (addSpawnPoints)

--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -226,7 +226,7 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
             Logger.ErrorS("preset", "Mind picked for traitor did not have an attached entity.");
             return false;
         }
-
+        
         // Calculate the amount of currency on the uplink.
         var startingBalance = _cfg.GetCVar(CCVars.TraitorStartingBalance);
         if (mind.CurrentJob != null)

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -257,6 +257,11 @@ namespace Content.Server.Ghost.Roles
             if (!TryComp(uid, out GhostRoleComponent? ghostRole))
                 return;
 
+            if (EntityManager.TryGetComponent(uid, out MindContainerComponent? mc))
+                if(mc.Mind != null)
+                    mc.Mind.MainPlayer = false;
+            
+
             ghostRole.Taken = true;
             UnregisterGhostRole(ghostRole);
         }

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -22,6 +22,8 @@ using Robust.Shared.Console;
 using Robust.Shared.Enums;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
+using Content.Server.SS220.TraitorComponentTarget;
+using Content.Server.Administration.Commands;
 
 namespace Content.Server.Ghost.Roles
 {
@@ -257,9 +259,10 @@ namespace Content.Server.Ghost.Roles
             if (!TryComp(uid, out GhostRoleComponent? ghostRole))
                 return;
 
-            if (EntityManager.TryGetComponent(uid, out MindContainerComponent? mc))
-                if(mc.Mind != null)
-                    mc.Mind.MainPlayer = false;
+
+
+            if (EntityManager.TryGetComponent(uid, out TraitorTargetComponent? tc))
+                EntityManager.RemoveComponent<TraitorTargetComponent>(uid);
             
 
             ghostRole.Taken = true;

--- a/Content.Server/Mind/Mind.cs
+++ b/Content.Server/Mind/Mind.cs
@@ -41,8 +41,6 @@ namespace Content.Server.Mind
         [ViewVariables, Access(typeof(MindSystem))]
         public NetUserId? UserId { get; set; }
 
-        [ViewVariables(VVAccess.ReadWrite)]
-        public bool MainPlayer { get; set; } = default!;
         /// <summary>
         ///     The session ID of the original owner, if any.
         ///     May end up used for round-end information (as the owner may have abandoned Mind since)

--- a/Content.Server/Mind/Mind.cs
+++ b/Content.Server/Mind/Mind.cs
@@ -41,6 +41,8 @@ namespace Content.Server.Mind
         [ViewVariables, Access(typeof(MindSystem))]
         public NetUserId? UserId { get; set; }
 
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool MainPlayer { get; set; } = default!;
         /// <summary>
         ///     The session ID of the original owner, if any.
         ///     May end up used for round-end information (as the owner may have abandoned Mind since)

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -296,6 +296,8 @@ public sealed class MindSystem : EntitySystem
         mind.Session?.AttachToEntity(entity);
         mind.VisitingEntity = entity;
 
+        mind.MainPlayer = false;
+
         // EnsureComp instead of AddComp to deal with deferred deletions.
         var comp = EnsureComp<VisitingMindComponent>(entity);
         comp.Mind = mind;
@@ -448,6 +450,7 @@ public sealed class MindSystem : EntitySystem
         if (!objectivePrototype.CanBeAssigned(mind))
             return false;
         var objective = objectivePrototype.GetObjective(mind);
+        
         if (mind.Objectives.Contains(objective))
             return false;
 

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -20,6 +20,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Content.Server.SS220.TraitorComponentTarget;
 
 namespace Content.Server.Mind;
 
@@ -296,7 +297,8 @@ public sealed class MindSystem : EntitySystem
         mind.Session?.AttachToEntity(entity);
         mind.VisitingEntity = entity;
 
-        mind.MainPlayer = false;
+        if (EntityManager.TryGetComponent(entity, out TraitorTargetComponent? tc))
+            EntityManager.RemoveComponent<TraitorTargetComponent>(entity);
 
         // EnsureComp instead of AddComp to deal with deferred deletions.
         var comp = EnsureComp<VisitingMindComponent>(entity);

--- a/Content.Server/Objectives/Conditions/KillRandomPersonCondition.cs
+++ b/Content.Server/Objectives/Conditions/KillRandomPersonCondition.cs
@@ -3,14 +3,16 @@ using Content.Server.Mind.Components;
 using Content.Server.Objectives.Interfaces;
 using Content.Shared.Mobs.Components;
 using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Objectives.Conditions
 {
     [UsedImplicitly]
     [DataDefinition]
-    public sealed class KillRandomPersonCondition : KillPersonCondition
+    public sealed class KillRandomPersonCondition : KillPersonCondition 
     {
+        // функция выбора задачи убийства со списка всех игорьков
         public override IObjectiveCondition GetAssigned(Mind.Mind mind)
         {
             var allHumans = EntityManager.EntityQuery<MindContainerComponent>(true).Where(mc =>
@@ -20,14 +22,20 @@ namespace Content.Server.Objectives.Conditions
                 if (entity == default)
                     return false;
 
+                // проверка на первостепенного персонажа
+                if (mc.Mind?.MainPlayer == false)
+                    return false;
+
                 if (EntityManager.IsQueuedForDeletion(entity!.Value))
                     return false;
+
 
                 return EntityManager.TryGetComponent(entity, out MobStateComponent? mobState) &&
                       MobStateSystem.IsAlive(entity.Value, mobState) &&
                        mc.Mind != mind;
             }).Select(mc => mc.Mind).ToList();
 
+            // Проверка на кол-во найденных игроков на задачу убийства
             if (allHumans.Count == 0)
                 return new DieCondition(); // I guess I'll die
 

--- a/Content.Server/Objectives/Conditions/KillRandomPersonCondition.cs
+++ b/Content.Server/Objectives/Conditions/KillRandomPersonCondition.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Server.Mind.Components;
 using Content.Server.Objectives.Interfaces;
+using Content.Server.SS220.TraitorComponentTarget;
 using Content.Shared.Mobs.Components;
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
@@ -15,31 +16,22 @@ namespace Content.Server.Objectives.Conditions
         // функция выбора задачи убийства со списка всех игорьков
         public override IObjectiveCondition GetAssigned(Mind.Mind mind)
         {
-            var allHumans = EntityManager.EntityQuery<MindContainerComponent>(true).Where(mc =>
-            {
-                var entity = mc.Mind?.OwnedEntity;
-                
-                if (entity == default)
-                    return false;
 
-                // проверка на первостепенного персонажа
-                if (mc.Mind?.MainPlayer == false)
-                    return false;
-
-                if (EntityManager.IsQueuedForDeletion(entity!.Value))
-                    return false;
-
-
-                return EntityManager.TryGetComponent(entity, out MobStateComponent? mobState) &&
-                      MobStateSystem.IsAlive(entity.Value, mobState) &&
-                       mc.Mind != mind;
-            }).Select(mc => mc.Mind).ToList();
+            var allTargets = EntityManager.EntityQuery<TraitorTargetComponent>(true).Where(tc => { if (tc.Owner == null) return false; return true; }).Select(
+                tc => {
+                    if(EntityManager.TryGetComponent<MindContainerComponent>(tc.Owner, out var mc))
+                    {
+                        if(mind != mc.Mind)
+                            return mc.Mind;
+                    }
+                    return null;
+                }).ToList();
 
             // Проверка на кол-во найденных игроков на задачу убийства
-            if (allHumans.Count == 0)
+            if (allTargets.Count == 0)
                 return new DieCondition(); // I guess I'll die
 
-            return new KillRandomPersonCondition {Target = IoCManager.Resolve<IRobustRandom>().Pick(allHumans)};
+            return new KillRandomPersonCondition {Target = IoCManager.Resolve<IRobustRandom>().Pick(allTargets) };
         }
     }
 }

--- a/Content.Server/Objectives/ObjectivesManager.cs
+++ b/Content.Server/Objectives/ObjectivesManager.cs
@@ -31,7 +31,7 @@ namespace Content.Server.Objectives
                     return null;
                 }
 
-                if (_prototypeManager.TryIndex<ObjectivePrototype>(group.Pick(_random), out var objective)
+                if (_prototypeManager.TryIndex<ObjectivePrototype>(group.Pick(_random), out var objective) 
                     && objective.CanBeAssigned(mind))
                     return objective;
                 else

--- a/Content.Server/SS220/TraitorComponentTarget/TraitorTargetComponent.cs
+++ b/Content.Server/SS220/TraitorComponentTarget/TraitorTargetComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.SS220.TraitorComponentTarget
+{
+    [RegisterComponent]
+    public sealed class TraitorTargetComponent : Component
+    {
+    }
+}

--- a/Content.Shared/Materials/MaterialStorageComponent.cs
+++ b/Content.Shared/Materials/MaterialStorageComponent.cs
@@ -40,6 +40,12 @@ public sealed class MaterialStorageComponent : Component
     public bool DropOnDeconstruct = true;
 
     /// <summary>
+    /// Переводим материалы в эквивалент руды и дропаем ее
+    /// </summary>
+    [DataField("dropMatsToOre")]
+    public bool DropMatsToOre = false;
+
+    /// <summary>
     /// Whitelist generated on runtime for what specific materials can be inserted into this entity.
     /// </summary>
     [DataField("materialWhiteList", customTypeSerializer: typeof(PrototypeIdListSerializer<MaterialPrototype>))]

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -713,7 +713,8 @@
     - type: Machine
       board: OreProcessorMachineCircuitboard
     - type: MaterialStorage
-      dropOnDeconstruct: false #should drop ores instead of ingots/sheets
+      dropOnDeconstruct: true #should drop ores instead of ingots/sheets
+      dropMatsToOre: true
       ignoreColor: true
       whitelist:
         tags:


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Проблема была описана тут 
https://discord.com/channels/1097181193939730453/1134446327355420702

**Медиа**
https://imgur.com/a/y3itJlR

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [+] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [+] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [+] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [+] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
- fix: теперь с печки выдаются руды при ее разборе

**MaterialStorageComponent** заимела переменную **DropOnDeconstruct**, которая поумолчанию **FALSE**, но в **lathe.yml** файле описания **OreProcessor** выдается **TRUE**.
При разборе печки идет условие на добавленную переменную, после из **MaterialStorage** спавнится руда пропорционально материалам находящимся внутри
