### PR TITLE
Wheelchair destruction bugfix

### DIFF
--- a/Content.Shared/Vehicle/SharedVehicleSystem.cs
+++ b/Content.Shared/Vehicle/SharedVehicleSystem.cs
@@ -17,6 +17,7 @@ using Content.Shared.Light.Component;
 using Content.Shared.Popups;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Vehicle;
 
@@ -28,6 +29,7 @@ namespace Content.Shared.Vehicle;
 public abstract partial class SharedVehicleSystem : EntitySystem
 {
     [Dependency] private readonly INetManager _netManager = default!;
+    [Dependency] protected readonly IGameTiming GameTiming = default!;
 
     [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
@@ -297,6 +299,14 @@ public abstract partial class SharedVehicleSystem : EntitySystem
     /// </summary>
     private void UpdateBuckleOffset(EntityUid uid, TransformComponent xform, VehicleComponent component)
     {
+        // So before this check this method tried to
+        // change offset of the rider whether the state
+        // was applying. This caused an issue with destroying
+        // the vehicle while someone was riding it. The rider
+        // was teleported to the local pos of offset on the client.
+        if (GameTiming.ApplyingState)
+            return;
+
         if (!TryComp<StrapComponent>(uid, out var strap))
             return;
 


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->
При попытке сломать коляску, если в коляске кто-то сидел, то сидевший в коляске будет телепортирован (у клиента). В процессе багфикса оказалось, что это проблема присуща всем транспортным средствам (уницикл, машина уборщика и т.д.).
**Медиа**
[видео](https://youtu.be/FbpzlLPnkHg)
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->

:cl:
- fix: исправлен телепорт людей при уничтожении транспорта
