### PR TITLE
Вещмешкам синдиката возвращено расширенное пространство

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -198,8 +198,6 @@
   name: syndicate pyjama duffel bag
   description: Contains 3 pairs of syndicate pyjamas and 3 plushies for the ultimate sleepover.
   components:
-  - type: Storage
-    maxTotalWeight: 44
   - type: StorageFill
     contents:
       - id: ClothingUniformJumpsuitPyjamaSyndicateRed

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -162,7 +162,6 @@
   description: A large duffel bag for holding various traitor goods.
   components:
   - type: Storage
-    maxItemSize: Huge
     maxTotalWeight: 44
   - type: Sprite
     sprite: Clothing/Back/Duffels/syndicate.rsi

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -161,6 +161,9 @@
   name: syndicate duffel bag
   description: A large duffel bag for holding various traitor goods.
   components:
+  - type: Storage
+    maxItemSize: Huge
+    maxTotalWeight: 44
   - type: Sprite
     sprite: Clothing/Back/Duffels/syndicate.rsi
 


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Изменена вместимость вещмешков синдиката: 40 -> 44
Всё как раньше, синдикат имеет сумки повышенной вместимости

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [+] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [+] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [+] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [+] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: Meower
- tweak: Изменена вместимость вещмешков синдиката
