### PR TITLE
Фикс старого объема сумок на новой системе хранения

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/Back/backpacks.yml
@@ -7,7 +7,7 @@
   - type: Sprite
     sprite: Corvax/Back/Backpacks/military.rsi
   - type: Storage
-    maxTotalWeight: 131
+    maxTotalWeight: 32   # SS220 backpack-fix
 
 - type: entity
   parent: ClothingBackpack
@@ -18,7 +18,7 @@
   - type: Sprite
     sprite: Corvax/Back/Backpacks/deathsquad-backpack.rsi
   - type: Storage
-    maxTotalWeight: 300
+    maxTotalWeight: 60   # SS220 backpack-fix
 
 - type: entity
   parent: ClothingBackpack
@@ -29,4 +29,4 @@
   - type: Sprite
     sprite: Corvax/Back/Backpacks/ce.rsi
   - type: Storage
-    maxTotalWeight: 100
+    maxTotalWeight: 28   # SS220 backpack-fix

--- a/Resources/Prototypes/Corvax/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/Back/duffel.yml
@@ -7,7 +7,7 @@
   - type: Sprite
     sprite: Corvax/Back/Duffels/military.rsi
   - type: Storage
-    maxTotalWeight: 200
+    maxTotalWeight: 44   # SS220 backpack-fix
 
 - type: entity
   parent: ClothingBackpackDuffel
@@ -18,4 +18,4 @@
   - type: Sprite
     sprite: Corvax/Back/Duffels/ce.rsi
   - type: Storage
-    maxTotalWeight: 120
+    maxTotalWeight: 40   # SS220 backpack-fix

--- a/Resources/Prototypes/Corvax/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/Back/satchel.yml
@@ -7,7 +7,7 @@
   - type: Sprite
     sprite: Corvax/Back/Satchels/military.rsi
   - type: Storage
-    maxTotalWeight: 131
+    maxTotalWeight: 32   # SS220 backpack-fix
 
 - type: entity
   parent: ClothingBackpackSatchel
@@ -19,4 +19,4 @@
     sprite: Corvax/Back/Satchels/ce.rsi
     state: icon
   - type: Storage
-    maxTotalWeight: 100
+    maxTotalWeight: 28   # SS220 backpack-fix


### PR DESCRIPTION
## Описание PR
Увынск. Теперь все виды рюкзаков СИ, армейских рюкзаков и рюкзак эскадрона смерти имеют вместимость, адаптированную под новую систему хранения.

**Проверки**
- [+] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [+] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [+] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [+] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:Meower
- fix: Объём некоторых сумок перенесен на новую систему хранения предметов.
