### PR TITLE
Revert delete TilePrying from Syndicate JOL

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -23,7 +23,7 @@
   - type: Tool
     qualities:
       - Prying
-    speed: 1.5
+    speed: 3
     useSound: /Audio/Items/jaws_pry.ogg
   - type: Prying
     pryPowered: true
@@ -61,11 +61,11 @@
   - type: Item
     size: Normal
   - type: TilePrying
-    advanced: false
+    advanced: true
   - type: Tool
     qualities:
       - Prying
-    speed: 3.0
+    speed: 1
   - type: MultipleTool
     entries:
       - behavior: Prying

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -17,13 +17,14 @@
     quickEquip: false
     slots:
       - Belt
+    #SS220 JOL TilePrying
   - type: TilePrying
     advanced: true
   - type: LatticeCutting
   - type: Tool
     qualities:
       - Prying
-    speed: 3
+    speed: 3 #SS220 JOL TilePrying
     useSound: /Audio/Items/jaws_pry.ogg
   - type: Prying
     pryPowered: true
@@ -60,12 +61,10 @@
     state: syn_jaws_pry
   - type: Item
     size: Normal
-  - type: TilePrying
-    advanced: true
   - type: Tool
     qualities:
       - Prying
-    speed: 1
+    speed: 1 #SS220 JOL TilePrying
   - type: MultipleTool
     entries:
       - behavior: Prying

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -17,9 +17,10 @@
     quickEquip: false
     slots:
       - Belt
-    #SS220 JOL TilePrying
+    #SS220 JOL TilePrying begin
   - type: TilePrying
     advanced: true
+    #SS220 JOL TilePrying end
   - type: LatticeCutting
   - type: Tool
     qualities:


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Возвращена возможность челюстям синдиката ковырять тайл "покрытие", но с большой разницей в скорости.
JOL НТ - 3
JOL Синди - 1

**Медиа**
Отсутствуют.

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->



:cl:Ady4
- add: Возвращена возможность Челюстям Жизни Синдиката снимать тайл "покрытие"
- tweak: Изменены скорости режима "Монтирование" для Челюстей Жизни.
