### PR TITLE
Возвращение удаленного космического медипена

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -68,7 +68,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingMaskBreathMedical
+      - id: ClothingMaskBreathMedicalSecurity
       - id: EmergencyOxygenTankFilled
       - id: EmergencyMedipen
       - id: SpaceMedipen # SS220 Revert deleted Medipen

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -9,6 +9,7 @@
       - id: ClothingMaskBreath
       - id: EmergencyOxygenTankFilled
       - id: EmergencyMedipen
+      - id: SpaceMedipen # SS220 Revert deleted Medipen
       - id: Flare
       - id: FoodTinMRE
       - id: DrinkWaterBottleFull
@@ -28,6 +29,7 @@
       - id: ClothingMaskBreath
       - id: ExtendedEmergencyOxygenTankFilled
       - id: EmergencyMedipen
+      - id: SpaceMedipen # SS220 Revert deleted Medipen
       - id: Flare
       - id: FoodTinMRE
       - id: DrinkWaterBottleFull
@@ -48,6 +50,7 @@
       - id: ClothingMaskGasSecurity
       - id: EmergencyOxygenTankFilled
       - id: EmergencyMedipen
+      - id: SpaceMedipen # SS220 Revert deleted Medipen
       - id: Flare
       - id: FoodTinMRE
       - id: DrinkWaterBottleFull
@@ -65,11 +68,11 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingMaskBreathMedicalSecurity
+      - id: ClothingMaskBreathMedical
       - id: EmergencyOxygenTankFilled
-      - id: SpaceMedipen
       - id: EmergencyMedipen
-      - id: EmergencyMedipen
+      - id: SpaceMedipen # SS220 Revert deleted Medipen
+      - id: Flare
       - id: FoodTinMRE
       - id: DrinkWaterBottleFull
   - type: Sprite
@@ -89,6 +92,7 @@
       - id: ClothingMaskBreathMedical
       - id: EmergencyOxygenTankFilled
       - id: EmergencyMedipen
+      - id: SpaceMedipen # SS220 Revert deleted Medipen
       - id: Flare
       - id: FoodTinMRE
       - id: DrinkWaterBottleFull
@@ -114,6 +118,7 @@
       - id: ClothingMaskBreath
       - id: EmergencyFunnyOxygenTankFilled
       - id: EmergencyMedipen
+      - id: SpaceMedipen # SS220 Revert deleted Medipen
       - id: Flare
       - id: FoodTinMRE
       - id: DrinkWaterBottleFull
@@ -132,6 +137,7 @@
       - id: ClothingMaskGasSyndicate
       - id: ExtendedEmergencyOxygenTankFilled
       - id: EmergencyMedipen
+      - id: SpaceMedipen # SS220 Revert deleted Medipen
       - id: Flare
       - id: FoodTinMRE
       - id: DrinkWaterBottleFull

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -296,7 +296,7 @@
   - type: SolutionContainerManager
     solutions:
       pen:
-        maxVol: 20
+        maxVol: 20 # SS220 Revert deleted medipen
         reagents:
           - ReagentId: Leporazine
             Quantity: 10 # SS220 Revert deleted medipen

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -292,16 +292,16 @@
     emptySpriteName: hypovolemic_empty
   - type: Hypospray
     solutionName: pen
-    transferAmount: 30
+    transferAmount: 20 # SS220 Revert deleted medipen
   - type: SolutionContainerManager
     solutions:
       pen:
-        maxVol: 30
+        maxVol: 20
         reagents:
           - ReagentId: Leporazine
-            Quantity: 10
+            Quantity: 10 # SS220 Revert deleted medipen
           - ReagentId: Barozine
-            Quantity: 20
+            Quantity: 10 # SS220 Revert deleted medipen
   - type: Tag
     tags: []
 


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
В результате ПРа оффов, они выпилили космический медипен у всех, кроме БМа. Я решил вернуть его, но сократить время до гиба до 49 секунд, уменьшив вместимость медипена до 20 юнитов и сбалансировав 2 реагента до 10 юнитов. Возможно, это будет эпохальное решение, но если что будет несложно откатить.
Ссылка на карточку на гите [тык](https://github.com/orgs/SerbiaStrong-220/projects/1?pane=issue&itemId=52067124)

**Медиа**
Нету.

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->


:cl:Ady4
- add: Добавлен космический медипен во все SurvivalBox.
- tweak: Изменен космический медипен.
