### PR TITLE
Mapping Light Fix, Neon Crystals

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/crystal_shard.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/crystal_shard.yml
@@ -44,11 +44,11 @@
   description: A small piece of crystal.
   components:
   - type: Sprite
-    color: "#47f8ff"
+    color: "#7df9ff" #SS220-Mapping-Light-Fix, Электрик
   - type: PointLight
     radius: 2
     energy: 2.5
-    color: "#47f8ff"
+    color: "#7df9ff" #SS220-Mapping-Light-Fix, Электрик
   - type: Tag
     tags:
       - Trash
@@ -60,11 +60,11 @@
   id: ShardCrystalBlue
   components:
   - type: Sprite
-    color: "#39a1ff"
+    color: "#5555ff" #SS220-Mapping-Light-Fix, Неоновый синий
   - type: PointLight
     radius: 2
     energy: 2.5
-    color: "#39a1ff"
+    color: "#5555ff" #SS220-Mapping-Light-Fix, Неоновый синий
   - type: Tag
     tags:
       - Trash
@@ -76,11 +76,11 @@
   name: orange crystal shard
   components:
   - type: Sprite
-    color: "#ff8227"
+    color: "#ffa420" #SS220-Mapping-Light-Fix, Люминесцентный оранжевый
   - type: PointLight
     radius: 2
     energy: 2.5
-    color: "#ff8227"
+    color: "#ffa420" #SS220-Mapping-Light-Fix, Люминесцентный оранжевый
   - type: Tag
     tags:
       - Trash
@@ -92,11 +92,11 @@
   name: pink crystal shard
   components:
   - type: Sprite
-    color: "#ff66cc"
+    color: "#fe019a" #SS220-Mapping-Light-Fix, Неоновый розовый
   - type: PointLight
     radius: 2
     energy: 2.5
-    color: "#ff66cc"
+    color: "#fe019a" #SS220-Mapping-Light-Fix, Неоновый розовый
   - type: Tag
     tags:
       - Trash
@@ -108,11 +108,11 @@
   name: green crystal shard
   components:
   - type: Sprite
-    color: "#52ff39"
+    color: "#39ff14" #SS220-Mapping-Light-Fix, Неоновый зелёный
   - type: PointLight
     radius: 2
     energy: 2.5
-    color: "#52ff39"
+    color: "#39ff14" #SS220-Mapping-Light-Fix, Неоновый зелёный
   - type: Tag
     tags:
       - Trash
@@ -124,11 +124,11 @@
   name: red crystal shard
   components:
   - type: Sprite
-    color: "#fb4747"
+    color: "#ff073a" #SS220-Mapping-Light-Fix, Неоновый красный
   - type: PointLight
     radius: 2
     energy: 2.5
-    color: "#fb4747"
+    color: "#ff073a" #SS220-Mapping-Light-Fix, Неоновый красный
   - type: Tag
     tags:
       - Trash

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -249,7 +249,7 @@
   id: LightTubeCrystalCyan
   components:
   - type: LightBulb
-    color: "#47f8ff"
+    color: "#7df9ff" #SS220-Mapping-Light-Fix, Электрик
     lightEnergy: 3
     lightRadius: 8
     lightSoftness: 0.5
@@ -269,7 +269,7 @@
   id: LightTubeCrystalBlue
   components:
   - type: LightBulb
-    color: "#39a1ff"
+    color: "#5555ff" #SS220-Mapping-Light-Fix, Неоновый синий
     lightEnergy: 3
     lightRadius: 8
     lightSoftness: 0.5
@@ -289,7 +289,7 @@
   id: LightTubeCrystalPink
   components:
   - type: LightBulb
-    color: "#ff66cc"
+    color: "#fe019a" #SS220-Mapping-Light-Fix, Неоновый розовый
     lightEnergy: 3
     lightRadius: 8
     lightSoftness: 0.5
@@ -309,7 +309,7 @@
   id: LightTubeCrystalOrange
   components:
   - type: LightBulb
-    color: "#ff8227"
+    color: "#ffa420" #SS220-Mapping-Light-Fix, Люминесцентный оранжевый
     lightEnergy: 3
     lightRadius: 8
     lightSoftness: 0.5
@@ -329,7 +329,7 @@
   id: LightTubeCrystalRed
   components:
   - type: LightBulb
-    color: "#fb4747"
+    color: "#ff073a" #SS220-Mapping-Light-Fix, Неоновый красный
     lightEnergy: 3
     lightRadius: 8
     lightSoftness: 0.5
@@ -349,7 +349,7 @@
   id: LightTubeCrystalGreen
   components:
   - type: LightBulb
-    color: "#52ff39"
+    color: "#39ff14" #SS220-Mapping-Light-Fix, Неоновый зелёный
     lightEnergy: 3
     lightRadius: 8
     lightSoftness: 0.5

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -130,6 +130,10 @@
   - type: Sprite
     state: base
   - type: PointLight
+    radius: 10 #SS220-Mapping-Light-Fix
+    energy: 0.8 #SS220-Mapping-Light-Fix
+    softness: 1 #SS220-Mapping-Light-Fix
+    color: "#FFE4CE" #SS220-Mapping-Light-Fix
     enabled: true
   - type: PoweredLight
     hasLampOnSpawn: LightTube
@@ -181,6 +185,11 @@
   components:
   - type: BloomLightMask # SS220 Grafon-Light
     useLightColor: true
+  - type: PointLight
+    radius: 12 #SS220-Mapping-Light-Fix
+    energy: 4.5 #SS220-Mapping-Light-Fix
+    softness: 0.5 #SS220-Mapping-Light-Fix
+    color: "#B4FCF0" #SS220-Mapping-Light-Fix
   - type: PoweredLight
     hasLampOnSpawn: ExteriorLightTube
     damage:
@@ -214,8 +223,8 @@
     useLightColor: true
   - type: PointLight
     radius: 10
-    energy: 2.5
-    softness: 0.9
+    energy: 4 #SS220-Mapping-Light-Fix
+    softness: 0.5 #SS220-Mapping-Light-Fix
     color: "#FFAF38"
 
 - type: entity
@@ -335,6 +344,10 @@
     state: base
   - type: PointLight
     enabled: true
+    color: "#FFAA66"
+    radius: 3.5 #SS220-Mapping-Light-Fix
+    energy: 0.9 #SS220-Mapping-Light-Fix
+    softness: 1.1 #SS220-Mapping-Light-Fix
   - type: PoweredLight
     hasLampOnSpawn: LightBulb
     damage:
@@ -401,7 +414,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#47f8ff"
+    color: "#7df9ff" #SS220-Mapping-Light-Fix, Электрик
 
 - type: entity
   id: AlwaysPoweredlightCyan
@@ -412,7 +425,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#47f8ff"
+    color: "#7df9ff" #SS220-Mapping-Light-Fix, Электрик
 
 - type: entity
   id: PoweredlightBlue
@@ -428,7 +441,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#39a1ff"
+    color: "#5555ff" #SS220-Mapping-Light-Fix, Неоновый синий
 
 - type: entity
   id: AlwaysPoweredlightBlue
@@ -439,7 +452,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#39a1ff"
+    color: "#5555ff" #SS220-Mapping-Light-Fix, Неоновый синий
 
 - type: entity
   id: PoweredlightPink
@@ -455,7 +468,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#ff66cc"
+    color: "#fe019a" #SS220-Mapping-Light-Fix, Неоновый розовый
 
 - type: entity
   id: AlwaysPoweredlightPink
@@ -466,7 +479,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#ff66cc"
+    color: "#fe019a" #SS220-Mapping-Light-Fix, Неоновый розовый
 
 - type: entity
   id: PoweredlightOrange
@@ -482,7 +495,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#ff8227"
+    color: "#ffa420" #SS220-Mapping-Light-Fix, Люминесцентный оранжевый
 
 - type: entity
   id: AlwaysPoweredlightOrange
@@ -493,7 +506,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#ff8227"
+    color: "#ffa420" #SS220-Mapping-Light-Fix, Люминесцентный оранжевый
 
 - type: entity
   id: PoweredlightRed
@@ -509,7 +522,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#fb4747"
+    color: "#ff073a" #SS220-Mapping-Light-Fix, Неоновый красный
 
 - type: entity
   id: AlwaysPoweredlightRed
@@ -520,7 +533,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#fb4747"
+    color: "#ff073a" #SS220-Mapping-Light-Fix, Неоновый красный
 
 - type: entity
   id: PoweredlightGreen
@@ -536,7 +549,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#52ff39"
+    color: "#39ff14" #SS220-Mapping-Light-Fix, Неоновый зелёный
 
 - type: entity
   id: AlwaysPoweredlightGreen
@@ -547,4 +560,4 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#52ff39"
+    color: "#39ff14" #SS220-Mapping-Light-Fix, Неоновый зелёный


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->
Теперь все светильники в маппинге светят также, как и в игре (очень важно, так как без этого очень сложно определить, даёт ли светильник достаточно света).
Цвет цветных светильников, ламп, осколков кристаллов и кристаллов приближен к неоновым версиям цветов.
**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->
![image](https://github.com/SerbiaStrong-220/space-station-14/assets/123590995/08994264-5bba-4bfe-86f8-c875b2749b3c)
![image](https://github.com/SerbiaStrong-220/space-station-14/assets/123590995/088ff73d-aed6-4648-a92b-4f7aef409283)
![image](https://github.com/SerbiaStrong-220/space-station-14/assets/123590995/bbc17ef4-f053-4012-af4a-28d1cf4aa2e6)
![image](https://github.com/SerbiaStrong-220/space-station-14/assets/123590995/a9e3d38a-10b6-4fee-a7e1-4f0cbbe7045e)

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- tweak: Цвет кристаллов, осколков кристаллов и ламп из кристаллов был изменён на неоновые версии.