### PR TITLE
Sponsor cigs now counts as trash for trashbag

### DIFF
--- a/Resources/Prototypes/SS220/Entities/Sponsor/items.yml
+++ b/Resources/Prototypes/SS220/Entities/Sponsor/items.yml
@@ -11,6 +11,7 @@
   - type: Tag
     tags:
       - Cigarette
+      - Trash
   - type: Clothing
     sprite: SS220/Objects/Sponsor/cigs/cigarette.rsi
     slots: [ mask ]


### PR DESCRIPTION
## Описание PR
Перфекционистов уборщиков ради - окурки спонсорских сигарет и сами сигареты теперь могут быть помещены в мешок для мусора.
**Медиа**
**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- tweak: Перфекционистов уборщиков ради - окурки спонсорских сигарет и сами сигареты теперь могут быть помещены в мешок для мусора.