### PR TITLE
PilotsGloves

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -63,7 +63,7 @@
       - id: ClothingBeltSecurityFilled
       - id: Flash
       - id: ClothingEyesGlassesSecurity
-      - id: ClothingHandsGlovesCombat
+#      - id: ClothingHandsGlovesCombat SS220 PilotsGloves
       - id: ClothingShoesBootsJack
       - id: ClothingEyesHudSecurity
       - id: ClothingOuterHardsuitSecurityPilot #ss220-pilot-hardsuit

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -186,6 +186,7 @@
   suffix: Empty
   components:
     - type: Item
+      size: Large #SS220 876
       sprite: Objects/Tanks/Jetpacks/mini.rsi
     - type: Sprite
       sprite: Objects/Tanks/Jetpacks/mini.rsi

--- a/Resources/Prototypes/SS220/Roles/Jobs/security_pilot.yml
+++ b/Resources/Prototypes/SS220/Roles/Jobs/security_pilot.yml
@@ -31,6 +31,7 @@
     id: SecurityPDA
     ears: ClothingHeadsetSecurity
     belt: ClothingBeltSecurityFilled
+    gloves: ClothingHandsGlovesCombat #SS220 PilotsGloves
     pocket1: WeaponPistolMk58Nonlethal
   innerClothingSkirt: ClothingUniformJumpskirtSec
   satchel: ClothingBackpackSatchelSecurityPilotFilled


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Перенес боевые перчатки пилотов из их шкафа на их роль. Связано с тем, что их воруют офицеры, а у пилотов отсутствует отдельный доступ. После добавление доступов пилота коммит "PilotsGloves" откатить.

Уменьшил размер мини джетпака. 


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl: Kemran
- tweak: Перчатки пилота перемещены из шкафа в раундстартовое снаряжение
