### PR TITLE
RemoveParamedicCrewMonitor

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -146,4 +146,4 @@
         prob: 0.3
       - id: OxygenTankFilled # SS220 - Changing the contents of the paramedic closet
       - id: NitrogenTankFilled # SS220 - Changing the contents of the paramedic closet
-      - id: HandheldCrewMonitor # SS220 - Changing the contents of the paramedic closet
+#RemoveParamedicCrewMonitor     - id: HandheldCrewMonitor # SS220 - Changing the contents of the paramedic closet 


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Убран портативный монитор экипажа из шкафчика парамедика, т.к. он хайриск, и он есть в шкафчике ГВ.


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl: Kemran, AliceValestray
- remove: Убран портативный монитор экипажа из шкафчика парамедика

