### PR TITLE
Self refillment for a gastank

### DIFF
--- a/Content.Server/SS220/Atmos/GasTankSelfRefillComponent.cs
+++ b/Content.Server/SS220/Atmos/GasTankSelfRefillComponent.cs
@@ -6,6 +6,6 @@ namespace Content.Server.SS220.Atmos
     [RegisterComponent]
     public sealed partial class GasTankSelfRefillComponent : Component
     {
-        [ViewVariables(VVAccess.ReadWrite)] [DataField("autoRefillRate")] public float AutoRefillRate { get; set; } = 0.5f;
+        [ViewVariables(VVAccess.ReadWrite)] [DataField("autoRefillRate")] public float AutoRefillRate { get; set; } = 0.1f; //slow gain over frame.
     }
 }

--- a/Content.Server/SS220/Atmos/GasTankSelfRefillComponent.cs
+++ b/Content.Server/SS220/Atmos/GasTankSelfRefillComponent.cs
@@ -1,0 +1,13 @@
+namespace Content.Server.SS220.Atmos
+{
+    /// <summary>
+    ///     Self-refilling tank.
+    /// </summary>
+    [RegisterComponent]
+    public sealed partial class GasTankSelfRefillComponent : Component
+    {
+        [ViewVariables(VVAccess.ReadWrite)] [DataField("autoRefill")] public bool AutoRefill = true; //{ get; set; }
+
+        [ViewVariables(VVAccess.ReadWrite)] [DataField("autoRefillRate")] public float AutoRefillRate = 0.5f;//{ get; set; }
+    }
+}

--- a/Content.Server/SS220/Atmos/GasTankSelfRefillComponent.cs
+++ b/Content.Server/SS220/Atmos/GasTankSelfRefillComponent.cs
@@ -6,8 +6,6 @@ namespace Content.Server.SS220.Atmos
     [RegisterComponent]
     public sealed partial class GasTankSelfRefillComponent : Component
     {
-        [ViewVariables(VVAccess.ReadWrite)] [DataField("autoRefill")] public bool AutoRefill = true; //{ get; set; }
-
-        [ViewVariables(VVAccess.ReadWrite)] [DataField("autoRefillRate")] public float AutoRefillRate = 0.5f;//{ get; set; }
+        [ViewVariables(VVAccess.ReadWrite)] [DataField("autoRefillRate")] public float AutoRefillRate { get; set; } = 0.5f;
     }
 }

--- a/Content.Server/SS220/Atmos/GasTankSelfRefillSystem.cs
+++ b/Content.Server/SS220/Atmos/GasTankSelfRefillSystem.cs
@@ -20,15 +20,18 @@ namespace Content.Server.SS220.Atmos
             var query = EntityQueryEnumerator<GasTankSelfRefillComponent, GasTankComponent>();
             while (query.MoveNext(out var uid, out var comp, out var tank))
             {
-                if (tank.IsValveOpen) //prevent air cycling
+                if (tank.IsValveOpen) //prevent air cycling and refillment when used
                     continue;
 
-                if(tank.Air.Pressure >= (1000 - comp.AutoRefillRate)) //fill if its lower than max.
+                if (tank.Air.Pressure >= (1000 - comp.AutoRefillRate)) //fill if its lower than 1000
                     continue;
-                /*
-                if(_atmosSys.GetContainingMixture(uid, excite: true) == null)
+
+                var tileMixture = _atmosSys.GetContainingMixture(uid, true);//smth i copypasted from GasAnalyzer
+                if (tileMixture == null)
                     continue;
-                */
+
+                if (tileMixture.Pressure == 0) //no preassure around == no refillment
+                    continue;
 
                 var mixSize = tank.Air.Volume;
                 var newMix = new GasMixture(mixSize);

--- a/Content.Server/SS220/Atmos/GasTankSelfRefillSystem.cs
+++ b/Content.Server/SS220/Atmos/GasTankSelfRefillSystem.cs
@@ -1,0 +1,31 @@
+using Content.Server.Atmos.Components;
+using Content.Shared.Atmos;
+using Content.Server.Atmos;
+
+namespace Content.Server.SS220.Atmos
+{
+    public sealed class GasTankSelfRefillSystem : EntitySystem
+    {
+        public override void Initialize()
+        {
+            base.Initialize();
+        }
+
+        //todo make refiilment from the atmosphere
+        public override void Update(float frameTime)
+        {
+            var query = EntityQueryEnumerator<GasTankSelfRefillComponent, GasTankComponent>();
+            while (query.MoveNext(out var uid, out var comp))
+            {
+                if (comp.IsValveOpen || comp.Air.Pressure >= (1000 - 0.5f))
+                    continue;
+
+                var mixSize = comp.Air.Volume;
+                var newMix = new GasMixture(mixSize);
+                newMix.SetMoles(Gas.Oxygen, ((comp.Air.Pressure + 0.5f) * mixSize) / (Atmospherics.R * Atmospherics.T20C)); // Fill the tank up to 1000KPA.
+                newMix.Temperature = Atmospherics.T20C;
+                comp.Air = newMix;
+            }
+        }
+    }
+}

--- a/Content.Server/SS220/Atmos/GasTankSelfRefillSystem.cs
+++ b/Content.Server/SS220/Atmos/GasTankSelfRefillSystem.cs
@@ -1,11 +1,14 @@
-using Content.Server.Atmos.Components;
 using Content.Shared.Atmos;
 using Content.Server.Atmos;
+using Content.Server.Atmos.Components;
+using Content.Server.Atmos.EntitySystems;
 
 namespace Content.Server.SS220.Atmos
 {
     public sealed class GasTankSelfRefillSystem : EntitySystem
     {
+        [Dependency] private readonly AtmosphereSystem _atmosSys = default!;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -15,16 +18,23 @@ namespace Content.Server.SS220.Atmos
         public override void Update(float frameTime)
         {
             var query = EntityQueryEnumerator<GasTankSelfRefillComponent, GasTankComponent>();
-            while (query.MoveNext(out var uid, out var comp))
+            while (query.MoveNext(out var uid, out var comp, out var tank))
             {
-                if (comp.IsValveOpen || comp.Air.Pressure >= (1000 - 0.5f))
+                if (tank.IsValveOpen) //prevent air cycling
                     continue;
 
-                var mixSize = comp.Air.Volume;
+                if(tank.Air.Pressure >= (1000 - comp.AutoRefillRate)) //fill if its lower than max.
+                    continue;
+                /*
+                if(_atmosSys.GetContainingMixture(uid, excite: true) == null)
+                    continue;
+                */
+
+                var mixSize = tank.Air.Volume;
                 var newMix = new GasMixture(mixSize);
-                newMix.SetMoles(Gas.Oxygen, ((comp.Air.Pressure + 0.5f) * mixSize) / (Atmospherics.R * Atmospherics.T20C)); // Fill the tank up to 1000KPA.
+                newMix.SetMoles(Gas.Oxygen, ((tank.Air.Pressure + comp.AutoRefillRate) * mixSize) / (Atmospherics.R * Atmospherics.T20C)); // Fill the tank
                 newMix.Temperature = Atmospherics.T20C;
-                comp.Air = newMix;
+                tank.Air = newMix;
             }
         }
     }

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -177,6 +177,9 @@
       moles:
         - 1.025689525 # oxygen
         - 1.025689525 # nitrogen
+  - type: GasTankSelfRefill
+  #    autoRefillRate: 200
+  #    autoRefill: True
 
 #Empty mini
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -177,8 +177,6 @@
       moles:
         - 1.025689525 # oxygen
         - 1.025689525 # nitrogen
-  - type: GasTankSelfRefill
-    autoRefillRate: 0.6
 
 #Empty mini
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -178,8 +178,7 @@
         - 1.025689525 # oxygen
         - 1.025689525 # nitrogen
   - type: GasTankSelfRefill
-  #    autoRefillRate: 200
-  #    autoRefill: True
+    autoRefillRate: 0.6
 
 #Empty mini
 - type: entity


### PR DESCRIPTION
## Описание PR
Влад попросил для обновы боргов компонент наполнения для джетпаков == добавил компонент пополнения сосудов с газом при условии, что они не открыты и что вокруг есть окружающая среда.

Когда-нибудь можно будет сделать так, чтобы они напрямую из окружающей среды засасывали воздух, но так как это в данный момент чисто для боргов то сойдет.
**Медиа**

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- add: Добавлен компонент позволяющий Сосудам с газами пополняться самостоятельно.
