### PR TITLE
Non-item disposal insert  bugfix

### DIFF
--- a/Content.Server/Containers/ThrowInsertContainerSystem.cs
+++ b/Content.Server/Containers/ThrowInsertContainerSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Throwing;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Random;
+using Content.Shared.Item;
 
 namespace Content.Server.Containers;
 
@@ -26,6 +27,11 @@ public sealed class ThrowInsertContainerSystem : EntitySystem
     private void OnThrowCollide(Entity<ThrowInsertContainerComponent> ent, ref ThrowHitByEvent args)
     {
         var container = _containerSystem.GetContainer(ent, ent.Comp.ContainerId);
+
+        //SS220 nonitem insert fix start
+        if (!HasComp<ItemComponent>(args.Thrown))
+            return;
+        //SS220 nonitem insert fix end
 
         if (!_containerSystem.CanInsert(args.Thrown, container))
             return;


### PR DESCRIPTION
## Описание PR
Ишшуе оффов в робасте, что при перетаскивании можно любой объект закинуть в мусорку. Сделал проверку, что это должен быть item.

**Медиа**
(https://discord.com/channels/1097181193939730453/1242267978347708416)

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- fix: В мусорку больше нельзя перетаскиванием закидывать предметы, которые нельзя взять в руки.