### PR TITLE
Измененные резисты пальто ГСН

### DIFF
--- a/Resources/Prototypes/SS220/Entities/Clothing/OuterClothing/SRTCoat.yml
+++ b/Resources/Prototypes/SS220/Entities/Clothing/OuterClothing/SRTCoat.yml
@@ -12,7 +12,13 @@
     sprite: SS220/Clothing/OuterClothing/Coats/SRTCoat.rsi
   - type: TemperatureProtection
     coefficient: 0.1
+  - type: ExplosionResistance
+    damageCoefficient: 0.9
   - type: Armor
     modifiers:
       coefficients:
-        Heat: 0.90
+        Heat: 0.7
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Caustic: 0.75


### PR DESCRIPTION
## Описание PR
Изменены резисты пальто ГСН в соответствии с описанием и трекером https://discord.com/channels/1097181193939730453/1244855768851812404. 
Статы такие же, как и у тренча ГСБ
**Медиа**
![photo_2024-05-28_18-11-55](https://github.com/SerbiaStrong-220/space-station-14/assets/171029900/af1d5c97-1dd7-4ccf-b722-49ef08587e34)

**Проверки**

- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

:cl:
- tweak: Изменена защита пальто ГСН в соответствии с описанием.