### PR TITLE
Измененные резисты полевой формы флота и комбинезона офицера NT

### DIFF
--- a/Resources/Prototypes/SS220/Entities/Clothing/OuterClothing/OfficerFieldUniform.yml
+++ b/Resources/Prototypes/SS220/Entities/Clothing/OuterClothing/OfficerFieldUniform.yml
@@ -13,4 +13,7 @@
   - type: Armor
     modifiers:
       coefficients:
+        Blunt: 0.70
+        Slash: 0.70
+        Piercing: 0.60
         Heat: 0.90

--- a/Resources/Prototypes/SS220/Entities/Clothing/Uniforms/CentCommOfificer_uniform.yml
+++ b/Resources/Prototypes/SS220/Entities/Clothing/Uniforms/CentCommOfificer_uniform.yml
@@ -10,3 +10,8 @@
     sprite: SS220/Clothing/Uniforms/nt_NO_uniform.rsi
   - type: Clothing
     sprite: SS220/Clothing/Uniforms/nt_NO_uniform.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Slash: 0.9
+        Piercing: 0.9


### PR DESCRIPTION
## Описание PR
Изменены резисты полевой формы Офицера Флота NT для соответствия описанию. Сохраняет защиту бронешинели ГСБ из комода с уменьшенным на 20% резистом к колющему.
Изменены резисты униформы Офицера NT для соответствия описанию. 
Извиняюсь, что в разных ПРах, хоть можно было и в одном.
## Медиа

**Добавленные резисты**

![image](https://github.com/SerbiaStrong-220/space-station-14/assets/171029900/179f232f-9055-4e5f-8454-b47bfaeedc50) 
![image](https://github.com/SerbiaStrong-220/space-station-14/assets/171029900/feb97497-20b5-48e6-aed3-a86956d4f700)

**Описание предметов**

![image](https://github.com/SerbiaStrong-220/space-station-14/assets/171029900/767c9955-19ce-4366-b9aa-ad6440de2fd3)
![image](https://github.com/SerbiaStrong-220/space-station-14/assets/171029900/6f6efb2f-d627-4acc-b4be-16d5ec868def)


**Проверки**

- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

:cl:
- tweak: Изменена защита полевой формы Офицера Флота NT
- tweak: Изменена защита униформы Офицера NT
