### PR TITLE
Game cards fix

### DIFF
--- a/Content.Shared/SS220/Appearance/ToggleAppearanceOnUseComponent.cs
+++ b/Content.Shared/SS220/Appearance/ToggleAppearanceOnUseComponent.cs
@@ -1,0 +1,26 @@
+// © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
+
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.SS220.Appearance;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ToggleAppearanceOnUseComponent : Component
+{
+    /// <summary>
+    ///     The current state of component appearance
+    /// </summary>
+    [ViewVariables, DataField("enabled")] public bool IsEnabled;
+}
+
+[Serializable, NetSerializable]
+public sealed class ToggleAppearanceOnUseState : ComponentState
+{
+    public bool IsEnabled;
+
+    public ToggleAppearanceOnUseState(bool isEnabled)
+    {
+        IsEnabled = isEnabled;
+    }
+}

--- a/Content.Shared/SS220/Appearance/ToggleAppearanceOnUseSystem.cs
+++ b/Content.Shared/SS220/Appearance/ToggleAppearanceOnUseSystem.cs
@@ -1,0 +1,57 @@
+// © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
+
+using Content.Shared.Interaction;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.SS220.Appearance;
+
+public sealed class ToggleAppearanceOnUseSystem : EntitySystem
+{
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ToggleAppearanceOnUseComponent, ComponentGetState>(OnGetState);
+        SubscribeLocalEvent<ToggleAppearanceOnUseComponent, ComponentHandleState>(OnHandleState);
+        SubscribeLocalEvent<ToggleAppearanceOnUseComponent, ActivateInWorldEvent>(OnActivate);
+    }
+
+    private void OnActivate(EntityUid uid, ToggleAppearanceOnUseComponent toggleComponent, ActivateInWorldEvent args)
+    {
+        SetAppearanceState((uid, toggleComponent), !toggleComponent.IsEnabled);
+    }
+
+    private void SetAppearanceState(Entity<ToggleAppearanceOnUseComponent?, AppearanceComponent?> entity, bool isEnabled)
+    {
+        if (!Resolve(entity, ref entity.Comp1, ref entity.Comp2) || entity.Comp1.IsEnabled == isEnabled)
+            return;
+
+        entity.Comp1.IsEnabled = isEnabled;
+        Dirty(entity, entity.Comp1);
+
+        _appearance.SetData(entity, GenericOnOffVisual.Visual, entity.Comp1.IsEnabled ? GenericOnOffVisual.On : GenericOnOffVisual.Off, entity.Comp2);
+    }
+
+    private void OnGetState(EntityUid uid, ToggleAppearanceOnUseComponent toggleComponent, ref ComponentGetState args)
+    {
+        args.State = new ToggleAppearanceOnUseState(toggleComponent.IsEnabled);
+    }
+
+    private void OnHandleState(EntityUid uid, ToggleAppearanceOnUseComponent toggleComponent, ref ComponentHandleState args)
+    {
+        if (args.Current is not ToggleAppearanceOnUseState state)
+            return;
+
+        SetAppearanceState((uid, toggleComponent), state.IsEnabled);
+    }
+}
+
+[Serializable, NetSerializable]
+public enum GenericOnOffVisual : sbyte
+{
+    Visual,
+    On,
+    Off
+}

--- a/Content.Shared/SS220/Appearance/ToggleAppearanceOnUseSystem.cs
+++ b/Content.Shared/SS220/Appearance/ToggleAppearanceOnUseSystem.cs
@@ -18,9 +18,9 @@ public sealed class ToggleAppearanceOnUseSystem : EntitySystem
         SubscribeLocalEvent<ToggleAppearanceOnUseComponent, ActivateInWorldEvent>(OnActivate);
     }
 
-    private void OnActivate(EntityUid uid, ToggleAppearanceOnUseComponent toggleComponent, ActivateInWorldEvent args)
+    private void OnActivate(Entity<ToggleAppearanceOnUseComponent> entity, ref ActivateInWorldEvent args)
     {
-        SetAppearanceState((uid, toggleComponent), !toggleComponent.IsEnabled);
+        SetAppearanceState((entity, entity.Comp), !entity.Comp.IsEnabled);
     }
 
     private void SetAppearanceState(Entity<ToggleAppearanceOnUseComponent?, AppearanceComponent?> entity, bool isEnabled)
@@ -34,17 +34,17 @@ public sealed class ToggleAppearanceOnUseSystem : EntitySystem
         _appearance.SetData(entity, GenericOnOffVisual.Visual, entity.Comp1.IsEnabled ? GenericOnOffVisual.On : GenericOnOffVisual.Off, entity.Comp2);
     }
 
-    private void OnGetState(EntityUid uid, ToggleAppearanceOnUseComponent toggleComponent, ref ComponentGetState args)
+    private void OnGetState(Entity<ToggleAppearanceOnUseComponent> entity, ref ComponentGetState args)
     {
-        args.State = new ToggleAppearanceOnUseState(toggleComponent.IsEnabled);
+        args.State = new ToggleAppearanceOnUseState(entity.Comp.IsEnabled);
     }
 
-    private void OnHandleState(EntityUid uid, ToggleAppearanceOnUseComponent toggleComponent, ref ComponentHandleState args)
+    private void OnHandleState(Entity<ToggleAppearanceOnUseComponent> entity, ref ComponentHandleState args)
     {
         if (args.Current is not ToggleAppearanceOnUseState state)
             return;
 
-        SetAppearanceState((uid, toggleComponent), state.IsEnabled);
+        SetAppearanceState((entity, entity.Comp), state.IsEnabled);
     }
 }
 

--- a/Resources/Prototypes/SS220/Entities/Objects/Fun/cards.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Fun/cards.yml
@@ -11,8 +11,7 @@
     - state: closedCard
   - type: Item
     size: Small
-  - type: TrayScanner
-    range: 0.01
+  - type: ToggleAppearanceOnUse
   - type: Appearance
   - type: Tag
     tags:
@@ -135,7 +134,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: pt }
@@ -146,7 +145,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: p2 }
@@ -157,7 +156,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: p3 }
@@ -168,7 +167,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: p4 }
@@ -179,7 +178,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: p5 }
@@ -190,7 +189,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: p6 }
@@ -201,7 +200,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: p7 }
@@ -212,7 +211,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: p8 }
@@ -223,7 +222,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: p9 }
@@ -234,7 +233,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: p10 }
@@ -245,7 +244,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: pd }
@@ -256,7 +255,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: pk }
@@ -267,7 +266,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: pv }
@@ -278,7 +277,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: kt }
@@ -289,7 +288,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: k2 }
@@ -300,7 +299,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: k3 }
@@ -311,7 +310,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: k4 }
@@ -322,7 +321,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: k5 }
@@ -333,7 +332,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: k6 }
@@ -344,7 +343,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: k7 }
@@ -355,7 +354,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: k8 }
@@ -366,7 +365,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: k9 }
@@ -377,7 +376,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: k10 }
@@ -388,7 +387,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: kd }
@@ -399,7 +398,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: kk }
@@ -410,7 +409,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: kv }
@@ -421,7 +420,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: ht }
@@ -432,7 +431,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: h2 }
@@ -443,7 +442,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: h3 }
@@ -454,7 +453,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: h4 }
@@ -465,7 +464,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: h5 }
@@ -476,7 +475,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: h6 }
@@ -487,7 +486,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: h7 }
@@ -498,7 +497,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: h8 }
@@ -509,7 +508,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: h9 }
@@ -520,7 +519,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: h10 }
@@ -531,7 +530,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: hd }
@@ -542,7 +541,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: hk }
@@ -553,7 +552,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: hv }
@@ -564,7 +563,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: bt }
@@ -575,7 +574,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: b2 }
@@ -586,7 +585,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: b3 }
@@ -597,7 +596,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: b4 }
@@ -608,7 +607,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: b5 }
@@ -619,7 +618,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: b6 }
@@ -630,7 +629,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: b7 }
@@ -641,7 +640,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: b8 }
@@ -652,7 +651,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: b9 }
@@ -663,7 +662,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: b10 }
@@ -674,7 +673,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: bd }
@@ -685,7 +684,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: bk }
@@ -696,7 +695,7 @@
   components:
   - type: GenericVisualizer
     visuals:
-      enum.TrayScannerVisual.Visual:
+      enum.GenericOnOffVisual.Visual:
         base:
           Off: { state: closedCard }
           On: { state: bv }


### PR DESCRIPTION
## Описание PR
Исправляет [баг игровых карт, которые в "включенном" состоянии просвечивают проводку под полом](https://discord.com/channels/1097181193939730453/1246528566238380122) путём замены `TrayScannerComponent` в прототипах карт на созданный `ToggleAppearanceOnUseComponent`, который просто меняет внешний вид без остального функционала, который был в `TrayScannerComponent`.

**Медиа**
![image](https://github.com/SerbiaStrong-220/space-station-14/assets/33173619/398c322b-b554-47c8-b0b2-9f4d3842fbb6)

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl:
- fix: Игральные карты больше не просвечивают проводку под полами.
