### PR TITLE
Crates labels fix

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -33,10 +33,12 @@
       visible: false
       map: ["enum.WeldableLayers.BaseWelded"]
 #SS220 Crate-tg-resprite end
+#SS220 crates-labels-fix begin
     - state: paper
       sprite: Structures/Storage/Crates/labels.rsi
       map: ["enum.PaperLabelVisuals.Layer"]
       offset: "0.0,0.375"
+#SS220 crates-labels-fix end
   - type: Construction
     graph: CratePlastic
     node: crateplastic
@@ -63,9 +65,11 @@
       visible: false
       map: ["enum.WeldableLayers.BaseWelded"]
 #SS220 Crate-tg-resprite end
+#SS220 crates-labels-fix begin
     - state: paper
       sprite: Structures/Storage/Crates/labels.rsi
       map: ["enum.PaperLabelVisuals.Layer"]
+#SS220 crates-labels-fix end
   - type: AntiRottingContainer
   - type: ExplosionResistance
     damageCoefficient: 0.50
@@ -88,9 +92,11 @@
       visible: false
       map: ["enum.WeldableLayers.BaseWelded"]
 #SS220 Crate-tg-resprite end
+#SS220 crates-labels-fix begin
     - state: paper
       sprite: Structures/Storage/Crates/labels.rsi
       map: ["enum.PaperLabelVisuals.Layer"]
+#SS220 crates-labels-fix end
 
 - type: entity
   parent: CratePlastic
@@ -110,9 +116,11 @@
       visible: false
       map: ["enum.WeldableLayers.BaseWelded"]
 #SS220 Crate-tg-resprite end
+#SS220 crates-labels-fix begin
     - state: paper
       sprite: Structures/Storage/Crates/labels.rsi
       map: ["enum.PaperLabelVisuals.Layer"]
+#SS220 crates-labels-fix end
 
 - type: entity
   parent: CrateGenericSteel
@@ -143,9 +151,11 @@
       visible: false
       map: ["enum.WeldableLayers.BaseWelded"]
 #SS220 Crate-tg-resprite end
+#SS220 crates-labels-fix begin
     - state: paper
       sprite: Structures/Storage/Crates/labels.rsi
       map: ["enum.PaperLabelVisuals.Layer"]
+#SS220 crates-labels-fix end
 
 - type: entity
   parent: CrateGenericSteel
@@ -165,9 +175,11 @@
       visible: false
       map: ["enum.WeldableLayers.BaseWelded"]
 #SS220 Crate-tg-resprite end
+#SS220 crates-labels-fix begin
     - state: paper
       sprite: Structures/Storage/Crates/labels.rsi
       map: ["enum.PaperLabelVisuals.Layer"]
+#SS220 crates-labels-fix end
 
 - type: entity
   parent: CrateGenericSteel

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -33,6 +33,10 @@
       visible: false
       map: ["enum.WeldableLayers.BaseWelded"]
 #SS220 Crate-tg-resprite end
+    - state: paper
+      sprite: Structures/Storage/Crates/labels.rsi
+      map: ["enum.PaperLabelVisuals.Layer"]
+      offset: "0.0,0.375"
   - type: Construction
     graph: CratePlastic
     node: crateplastic
@@ -59,6 +63,9 @@
       visible: false
       map: ["enum.WeldableLayers.BaseWelded"]
 #SS220 Crate-tg-resprite end
+    - state: paper
+      sprite: Structures/Storage/Crates/labels.rsi
+      map: ["enum.PaperLabelVisuals.Layer"]
   - type: AntiRottingContainer
   - type: ExplosionResistance
     damageCoefficient: 0.50
@@ -81,6 +88,9 @@
       visible: false
       map: ["enum.WeldableLayers.BaseWelded"]
 #SS220 Crate-tg-resprite end
+    - state: paper
+      sprite: Structures/Storage/Crates/labels.rsi
+      map: ["enum.PaperLabelVisuals.Layer"]
 
 - type: entity
   parent: CratePlastic
@@ -100,6 +110,9 @@
       visible: false
       map: ["enum.WeldableLayers.BaseWelded"]
 #SS220 Crate-tg-resprite end
+    - state: paper
+      sprite: Structures/Storage/Crates/labels.rsi
+      map: ["enum.PaperLabelVisuals.Layer"]
 
 - type: entity
   parent: CrateGenericSteel
@@ -130,6 +143,9 @@
       visible: false
       map: ["enum.WeldableLayers.BaseWelded"]
 #SS220 Crate-tg-resprite end
+    - state: paper
+      sprite: Structures/Storage/Crates/labels.rsi
+      map: ["enum.PaperLabelVisuals.Layer"]
 
 - type: entity
   parent: CrateGenericSteel
@@ -149,6 +165,9 @@
       visible: false
       map: ["enum.WeldableLayers.BaseWelded"]
 #SS220 Crate-tg-resprite end
+    - state: paper
+      sprite: Structures/Storage/Crates/labels.rsi
+      map: ["enum.PaperLabelVisuals.Layer"]
 
 - type: entity
   parent: CrateGenericSteel

--- a/Resources/Prototypes/SS220/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/SS220/Entities/Structures/Storage/Crates/crates.yml
@@ -17,6 +17,10 @@
     - state: welded
       visible: false
       map: ["enum.WeldableLayers.BaseWelded"]
+    - state: paper
+      sprite: Structures/Storage/Crates/labels.rsi
+      map: ["enum.PaperLabelVisuals.Layer"]
+      offset: "-0.03125,0.28125"
 
 - type: entity
   parent: CrateGeneric
@@ -31,6 +35,10 @@
     - state: base
     - state: closed
       map: ["enum.StorageVisualLayers.Door"]
+    - state: paper
+      sprite: Structures/Storage/Crates/labels.rsi
+      map: ["enum.PaperLabelVisuals.Layer"]
+      offset: "-0.03125,0.28125"
   - type: Icon
     sprite: SS220/Structures/Storage/Crates/wood_crate.rsi
     state: base


### PR DESCRIPTION
## Описание PR
Исправляет [визуальный баг с надписями ERROR на некоторых ящиках вместо этикетки](https://discord.com/channels/1097181193939730453/1235901196426936410) (см. медиа)~, каргония может спать спокойно~.

**Медиа**
До:
![CratesError](https://github.com/SerbiaStrong-220/space-station-14/assets/33173619/56113b4f-ca01-4cff-a5ef-cd4d39e5c614)
После:
![CratesFixed](https://github.com/SerbiaStrong-220/space-station-14/assets/33173619/30e86e7c-fc95-4fb4-ba2f-a75123d9db0a)

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl:
- fix: Некоторые ящики больше не показывают надпись ERROR вместо этикетки.