### PR TITLE
fix: Цвет хвоста, морды и т.п., после обращения в зомби

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -40,6 +40,7 @@ using Content.Shared.Traits.Assorted;
 using Robust.Shared.Audio.Systems;
 using Content.Shared.Clothing;
 using Content.Server.Administration.Managers;
+using Content.Shared.Humanoid.Markings;
 using Robust.Server.Player;
 
 namespace Content.Server.Zombies
@@ -171,6 +172,13 @@ namespace Content.Server.Zombies
                 _humanoidAppearance.SetBaseLayerId(target, HumanoidVisualLayers.HeadSide, zombiecomp.BaseLayerExternal, humanoid: huApComp);
                 _humanoidAppearance.SetBaseLayerId(target, HumanoidVisualLayers.HeadTop, zombiecomp.BaseLayerExternal, humanoid: huApComp);
                 _humanoidAppearance.SetBaseLayerId(target, HumanoidVisualLayers.Snout, zombiecomp.BaseLayerExternal, humanoid: huApComp);
+
+                //ss220 - start edit
+                SetMarkingColors(MarkingCategories.Tail, zombiecomp.SkinColor, huApComp);
+                SetMarkingColors(MarkingCategories.HeadSide, zombiecomp.SkinColor, huApComp);
+                SetMarkingColors(MarkingCategories.HeadTop, zombiecomp.SkinColor, huApComp);
+                SetMarkingColors(MarkingCategories.Snout, zombiecomp.SkinColor, huApComp);
+                //ss220 - end edit
 
                 //This is done here because non-humanoids shouldn't get baller damage
                 //lord forgive me for the hardcoded damage

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Bed.Sleep;
 using Content.Shared.Cloning;
 using Content.Shared.Damage;
 using Content.Shared.Humanoid;
+using Content.Shared.Humanoid.Markings;
 using Content.Shared.Inventory;
 using Content.Shared.Mind;
 using Content.Shared.Mobs;
@@ -273,6 +274,20 @@ namespace Content.Server.Zombies
             }
         }
 
+        // ss220 - zombie - edit start
+        private void SetMarkingColors(MarkingCategories category, Color color, HumanoidAppearanceComponent huApComp)
+        {
+            if (!huApComp.MarkingSet.TryGetCategory(category, out var markings))
+                return;
+
+            var index = markings.Count - 1;
+            for (var i = 0; i < markings[index].MarkingColors.Count; i++)
+            {
+                markings[index].SetColor(i, color);
+            }
+        }
+        // ss220 - zombie - edit end
+
         /// <summary>
         ///     This is the function to call if you want to unzombify an entity.
         /// </summary>
@@ -296,6 +311,14 @@ namespace Content.Server.Zombies
             if (TryComp<HumanoidAppearanceComponent>(target, out var appcomp))
             {
                 appcomp.EyeColor = zombiecomp.BeforeZombifiedEyeColor;
+
+                //ss220 edit start
+                SetMarkingColors(MarkingCategories.Tail, zombiecomp.BeforeZombifiedSkinColor, appcomp);
+                SetMarkingColors(MarkingCategories.HeadSide, zombiecomp.BeforeZombifiedSkinColor, appcomp);
+                SetMarkingColors(MarkingCategories.HeadTop, zombiecomp.BeforeZombifiedSkinColor, appcomp);
+                SetMarkingColors(MarkingCategories.Snout, zombiecomp.BeforeZombifiedSkinColor, appcomp);
+                //ss220 edit end
+
             }
             _humanoidAppearance.SetSkinColor(target, zombiecomp.BeforeZombifiedSkinColor, false);
             _bloodstream.ChangeBloodReagent(target, zombiecomp.BeforeZombifiedBloodReagent);


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Отображение хвостов, морды, крыльев у существа после обращения в зомби (fixes https://github.com/SerbiaStrong-220/space-station-14/issues/1136)

**Медиа**
![image](https://github.com/SerbiaStrong-220/space-station-14/assets/63300653/21848fa1-58d1-40c2-ade3-c9fa6c56f8f9)
![image](https://github.com/SerbiaStrong-220/space-station-14/assets/63300653/f71b3462-7826-46bc-b2c5-06c2f75369ef)
![image](https://github.com/SerbiaStrong-220/space-station-14/assets/63300653/b1ee441b-73e5-4cc4-8d78-d8928cf86df2)


**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- fix: Цвет хвоста после обращения в зомби
