### PR TITLE
Agent card chat fix

### DIFF
--- a/Content.Server/Access/Systems/AgentIDCardSystem.cs
+++ b/Content.Server/Access/Systems/AgentIDCardSystem.cs
@@ -77,6 +77,11 @@ namespace Content.Server.Access.Systems
                 return;
 
             _cardSystem.TryChangeJobTitle(uid, args.Job, idCard);
+
+            // SS220 Radio-Job-Color-start
+            if (TryFindJobProtoFromJobName(args.Job.ToLowerInvariant(), out var job))
+                _cardSystem.TryChangeJobColor(uid, PresetIdCardSystem.GetJobColor(_prototypeManager, job), job.RadioIsBold);
+            // SS220 Radio-Job-Color-end
         }
 
         private void OnNameChanged(EntityUid uid, AgentIDCardComponent comp, AgentIDCardNameChangedMessage args)
@@ -103,11 +108,36 @@ namespace Content.Server.Access.Systems
 
         private bool TryFindJobProtoFromIcon(StatusIconPrototype jobIcon, [NotNullWhen(true)] out JobPrototype? job)
         {
+          foreach (var jobPrototype in _prototypeManager.EnumeratePrototypes<JobPrototype>())
+          {
+              if (jobPrototype.Icon == jobIcon.ID)
+              {
+                  job = jobPrototype;
+                  return true;
+              }
+          }
+
+          job = null;
+          return false;
+        }
+
+        // SS220 Radio-Job-Color-start
+        private bool TryFindJobProtoFromJobName(string jobName, [NotNullWhen(true)] out JobPrototype? job)
+        {
             foreach (var jobPrototype in _prototypeManager.EnumeratePrototypes<JobPrototype>())
             {
-                if (jobPrototype.Icon == jobIcon.ID)
+                if (jobPrototype.LocalizedName == jobName)
                 {
                     job = jobPrototype;
+                    return true;
+                }
+            }
+
+            foreach (var jobPrototypePassenger in _prototypeManager.EnumeratePrototypes<JobPrototype>())
+            {
+                if (jobPrototypePassenger.LocalizedName == "пассажир")
+                {
+                    job = jobPrototypePassenger;
                     return true;
                 }
             }
@@ -115,5 +145,6 @@ namespace Content.Server.Access.Systems
             job = null;
             return false;
         }
-    }
+      // SS220 Radio-Job-Color-end
+      }
 }

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -85,7 +85,7 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
 
             var jobProto = new ProtoId<AccessLevelPrototype>(string.Empty);
             if (TryComp<StationRecordKeyStorageComponent>(targetId, out var keyStorage)
-                && keyStorage.Key is {} key
+                && keyStorage.Key is { } key
                 && _record.TryGetRecord<GeneralStationRecord>(key, out var record))
             {
                 jobProto = record.JobPrototype;

--- a/Content.Server/Access/Systems/PresetIdCardSystem.cs
+++ b/Content.Server/Access/Systems/PresetIdCardSystem.cs
@@ -96,7 +96,7 @@ public sealed class PresetIdCardSystem : EntitySystem
         var departments = prototypeManager.EnumeratePrototypes<DepartmentPrototype>().ToList();
         departments.Sort((a, b) => a.Sort.CompareTo(b.Sort));
 
-        foreach (var department in departments.Where(department => department.Roles.Contains(jobCode)))
+        foreach (var department in departments.Where(department => department.Roles.Contains(jobCode))) // SS220 Radio-Job-Color
         {
             return department.Color.ToHex();
         }

--- a/Content.Server/Access/Systems/PresetIdCardSystem.cs
+++ b/Content.Server/Access/Systems/PresetIdCardSystem.cs
@@ -96,10 +96,7 @@ public sealed class PresetIdCardSystem : EntitySystem
         var departments = prototypeManager.EnumeratePrototypes<DepartmentPrototype>().ToList();
         departments.Sort((a, b) => a.Sort.CompareTo(b.Sort));
 
-        foreach (var department in from department in departments
-                from jobId in department.Roles
-                where jobId == jobCode
-                select department)
+        foreach (var department in departments.Where(department => department.Roles.Contains(jobCode)))
         {
             return department.Color.ToHex();
         }

--- a/Content.Shared/Access/Systems/SharedIdCardSystem.cs
+++ b/Content.Shared/Access/Systems/SharedIdCardSystem.cs
@@ -166,7 +166,7 @@ public abstract class SharedIdCardSystem : EntitySystem
 
         id.JobColor = jobColor;
         id.RadioBold = boldRadio;
-        Dirty(id);
+        Dirty(uid, id);
         UpdateEntityName(uid, id);
 
         if (player != null)


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Фиксит ошибку из-за которой не меняется цветное отображение должности в чате при ее смене с помощью агентской карты(вне зависимости от названия профессии и значка для визора цвет должности всегда как у пассажира)
Фикс работает только при условии если название профессии написано правильно(значок визора все еще не влияет на отображение в чате).

**Медиа**
Было:
![1](https://github.com/SerbiaStrong-220/space-station-14/assets/26493665/27e953a8-e557-4aee-ba24-f7122204bb0c)

Стало:
![2](https://github.com/SerbiaStrong-220/space-station-14/assets/26493665/21a1253c-7139-40f7-9635-a04a2fa0320d)

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
🆑 Lemird / 13lackHawk
- fix: Исправлено некорректное цветное отображение профессии у агентской ID карты при отправке сообщений в рацию. Для корректного отображения цвета фейковой должности не забывайте писать существующее название профессии.
