### PR TITLE
Fix end round manifest and NukeOps

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -475,7 +475,14 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         if (_mindSlave.EnslavedMinds.Count > 0)
         {
             foreach (var slave in _mindSlave.EnslavedMinds)
-                args.Minds.Add((slave.Key, Name(slave.Key)));
+            {
+                if (TryComp<MetaDataComponent>(slave.Key, out var comp) && comp != null)
+                    args.Minds.Add((slave.Key, Name(slave.Key)));
+                _mindSlave.EnslavedMinds.Remove(slave.Key); // Problem is we dont clean slaved minds during the round.
+                // Whats why you cant slave someone whos mind was slaved anymatter on which puppet they were.
+                // Also is it intedented that EnslavedMinds exists with all information even after restart?
+                // I think that it is done to show all slaved during the round, but...
+            }
         }
         //SS22-mindslave-end
 

--- a/Content.Server/GameTicking/Rules/LoadMapRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/LoadMapRuleSystem.cs
@@ -1,5 +1,7 @@
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.GridPreloader;
+using Content.Server.Pinpointer;
+using Content.Server.Station.Components;
 using Content.Shared.GameTicking.Components;
 using Robust.Server.GameObjects;
 using Robust.Server.Maps;
@@ -65,6 +67,11 @@ public sealed class LoadMapRuleSystem : GameRuleSystem<LoadMapRuleComponent>
             _transform.SetParent(loadedShuttle.Value, mapUid);
             grids = new List<EntityUid>() { loadedShuttle.Value };
             _map.InitializeMap(mapUid);
+            // SS220 LoneOps TC-adding-fix BEGIN
+            var mapName = comp.PreloadedGrid.ToString();
+            if (mapName != null)
+                _metaData.SetEntityName(mapUid, mapName, MetaData(mapUid));
+            // SS220 LoneOps TC-adding-fix END
         }
         else
         {

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -99,4 +99,6 @@
   id: SyndicateLoneOperativeGearFull
   parent: SyndicateOperativeGearFull
   equipment:
-    pocket2: BaseUplinkRadio40TC
+    pocket2: LoneOpsUplinkRadio40TC
+  inhand:
+    - NukeLoneOpsDeclarationOfWar


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->

В манифест вернутся слейвы, больше они не будут строить себе вечный памятник в никуда.
Одиночный оперативник снова станет одиночным. 
Ядерные оперативники вновь смогут объявлять войну... как я закончу разбираться...

fix #1291
fix #1282 

**TODO**
- [ ] FTL у яо не блокируется после начала войны
- [ ] Проверить может ли исправление проблемы с шаттлом упростить код
- [ ] Проверить маскировку шаттлов ЯО


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [ ] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [ ] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->


:cl: AlwyAnri
- fix: Исправлены ошибки из-за которых не было манифеста после конца раунда
- fix: Исправлен аплинк у одиночного ядерного оперативника
- fix: Исправлено объявление войны у ядерных оперативников
