### PR TITLE
Fix end round and lone ops uplink

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -471,16 +471,22 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         args.Minds = ent.Comp.SelectedMinds;
 
         //SS22-mindslave-begin
-        //such a hack, and I'm lazy to do a shit about this
+        //such a hack, and I'm lazy to do a shit about this <- yeah, yeah (c) bugfixer
         if (_mindSlave.EnslavedMinds.Count > 0)
         {
             foreach (var slave in _mindSlave.EnslavedMinds)
             {
                 if (TryComp<MetaDataComponent>(slave.Key, out var comp) && comp != null)
-                    args.Minds.Add((slave.Key, Name(slave.Key)));
+                    if (Name(slave.Key) != null)
+                    {
+                        int firstNameSymbol = Name(slave.Key).IndexOf('(') + 1;
+                        int lastNameSymbol = Name(slave.Key).LastIndexOf(')');
+                        var correctSlaveName = Name(slave.Key);
+                        if (firstNameSymbol != -1 || lastNameSymbol != -1)
+                            correctSlaveName = Name(slave.Key).Substring(firstNameSymbol, lastNameSymbol - firstNameSymbol);
+                        args.Minds.Add((slave.Key, correctSlaveName));
+                    }
                 _mindSlave.EnslavedMinds.Remove(slave.Key); // Problem is we dont clean slaved minds during the round.
-                // Whats why you cant slave someone whos mind was slaved anymatter on which puppet they were.
-                // Also is it intedented that EnslavedMinds exists with all information even after restart?
             }
         }
         //SS22-mindslave-end

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -472,23 +472,20 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
 
         //SS22-mindslave-begin
         //such a hack, and I'm lazy to do a shit about this <- yeah, yeah (c) bugfixer
-        if (_mindSlave.EnslavedMinds.Count > 0)
+        foreach (var slave in _mindSlave.EnslavedMinds)
         {
-            foreach (var slave in _mindSlave.EnslavedMinds)
-            {
-                if (TryComp<MetaDataComponent>(slave.Key, out var comp) && comp != null)
-                    if (Name(slave.Key) != null)
-                    {
-                        int firstNameSymbol = Name(slave.Key).IndexOf('(') + 1;
-                        int lastNameSymbol = Name(slave.Key).LastIndexOf(')');
-                        var correctSlaveName = Name(slave.Key);
-                        if (firstNameSymbol != -1 || lastNameSymbol != -1)
-                            correctSlaveName = Name(slave.Key).Substring(firstNameSymbol, lastNameSymbol - firstNameSymbol);
-                        args.Minds.Add((slave.Key, correctSlaveName));
-                    }
-                _mindSlave.EnslavedMinds.Remove(slave.Key); // Problem is we dont clean slaved minds during the round.
-            }
+            if (HasComp<MetaDataComponent>(slave.Key)) // we have deleted minds in EnslavedMinds because we clear them only if we have traitors
+                if (Name(slave.Key) != null)
+                {
+                    int firstNameSymbol = Name(slave.Key).IndexOf('(') + 1;
+                    int lastNameSymbol = Name(slave.Key).LastIndexOf(')');
+                    var correctSlaveName = Name(slave.Key);
+                    if (firstNameSymbol != -1 || lastNameSymbol != -1)
+                        correctSlaveName = Name(slave.Key)[firstNameSymbol..lastNameSymbol];
+                    args.Minds.Add((slave.Key, correctSlaveName));
+                }
         }
+        _mindSlave.EnslavedMinds.Clear(); // Problem is we dont clear slaved minds on new round start.
         //SS22-mindslave-end
 
         args.AgentName = Loc.GetString(name);

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -472,11 +472,17 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
 
         //SS22-mindslave-begin
         //such a hack, and I'm lazy to do a shit about this
-        //if (_mindSlave.EnslavedMinds.Count > 0)
-        //{
-        //    foreach (var slave in _mindSlave.EnslavedMinds)
-        //        args.Minds.Add((slave.Key, Name(slave.Key)));
-        //}
+        if (_mindSlave.EnslavedMinds.Count > 0)
+        {
+            foreach (var slave in _mindSlave.EnslavedMinds)
+            {
+                if (TryComp<MetaDataComponent>(slave.Key, out var comp) && comp != null)
+                    args.Minds.Add((slave.Key, Name(slave.Key)));
+                _mindSlave.EnslavedMinds.Remove(slave.Key); // Problem is we dont clean slaved minds during the round.
+                // Whats why you cant slave someone whos mind was slaved anymatter on which puppet they were.
+                // Also is it intedented that EnslavedMinds exists with all information even after restart?
+            }
+        }
         //SS22-mindslave-end
 
         args.AgentName = Loc.GetString(name);

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -99,4 +99,4 @@
   id: SyndicateLoneOperativeGearFull
   parent: SyndicateOperativeGearFull
   equipment:
-    pocket2: BaseUplinkRadio40TC
+    pocket2: LoneOpsUplinkRadio40TC


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->

Исправлено отображение имён слейвов в таблице целей после конца раунда.
ЛонОпу вернули его собственный аплинк. 
fix #1282 

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->

:cl: AlwyAnri
- fix: Исправлена ошибка отображение таблицы конца раунда!
- fix: Исправлен аплинк у лонопа!
