### PR TITLE
fix: Исправлены крысиные слуги

### DIFF
--- a/Content.Shared/RatKing/SharedRatKingSystem.cs
+++ b/Content.Shared/RatKing/SharedRatKingSystem.cs
@@ -1,7 +1,10 @@
 ﻿using Content.Shared.Actions;
 using Content.Shared.DoAfter;
+using Content.Shared.Item;
+using Content.Shared.Mobs;
 using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
+using Content.Shared.Tag;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -20,6 +23,7 @@ public abstract class SharedRatKingSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _action = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly TagSystem _tagSystem = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -29,6 +33,7 @@ public abstract class SharedRatKingSystem : EntitySystem
         SubscribeLocalEvent<RatKingComponent, RatKingOrderActionEvent>(OnOrderAction);
 
         SubscribeLocalEvent<RatKingServantComponent, ComponentShutdown>(OnServantShutdown);
+        SubscribeLocalEvent<RatKingServantComponent, MobStateChangedEvent>(OnServantDie);
 
         SubscribeLocalEvent<RatKingRummageableComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerb);
         SubscribeLocalEvent<RatKingRummageableComponent, RatKingRummageDoAfterEvent>(OnDoAfterComplete);
@@ -87,6 +92,18 @@ public abstract class SharedRatKingSystem : EntitySystem
         if (TryComp(component.King, out RatKingComponent? ratKingComponent))
             ratKingComponent.Servants.Remove(uid);
     }
+
+    //ss220 rat servant fix begin
+    private void OnServantDie(EntityUid uid, RatKingServantComponent component, MobStateChangedEvent args)
+    {
+        if (args.NewMobState != MobState.Dead && args.OldMobState != MobState.Dead)
+            return;
+
+        EnsureComp<ItemComponent>(uid);
+
+        _tagSystem.AddTag(uid, "Trash");
+    }
+    //ss220 rat servant fix end
 
     private void UpdateActions(EntityUid uid, RatKingComponent? component = null)
     {

--- a/Content.Shared/RatKing/SharedRatKingSystem.cs
+++ b/Content.Shared/RatKing/SharedRatKingSystem.cs
@@ -96,7 +96,7 @@ public abstract class SharedRatKingSystem : EntitySystem
     //ss220 rat servant fix begin
     private void OnServantDie(EntityUid uid, RatKingServantComponent component, MobStateChangedEvent args)
     {
-        if (args.NewMobState != MobState.Dead && args.OldMobState != MobState.Dead)
+        if (args.NewMobState != MobState.Dead)
             return;
 
         EnsureComp<ItemComponent>(uid);


### PR DESCRIPTION
## Описание PR
fix: Теперь мёртвых крысиных слуг можно взять на руки, положить в рюкзак. смыть в мусорку и т.д. (fix https://github.com/SerbiaStrong-220/space-station-14/issues/1172)

**Медиа**

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- fix: Теперь мёртвых крысиных слуг можно выкидывать!
