### PR TITLE
fix: Синди худы снова отображаются на лице

### DIFF
--- a/Resources/Prototypes/SS220/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/SS220/Entities/Clothing/Eyes/hud.yml
@@ -7,7 +7,7 @@
   - type: Sprite
     sprite: SS220/Clothing/Eyes/syndchem.rsi
   - type: Clothing
-    sprite: SS220/Clothing/Eyes/Hud/syndchem.rsi
+    sprite: SS220/Clothing/Eyes/syndchem.rsi
   - type: ShowHealthBars
     damageContainers:
     - Biological


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Синди худы снова отображаются на лице (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1426)

**Медиа**

![image](https://github.com/user-attachments/assets/197ec7e0-4905-42a5-b6b7-adc9d0403a00)


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- fix: Синди худы снова отображаются на лице
