### PR TITLE
add: Уникальность сообщений, задержка перед отправкой

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -73,6 +73,9 @@ public sealed partial class ChatSystem : SharedChatSystem
     public const string DefaultAnnouncementSound = "/Audio/Announcements/announce.ogg";
     public const string CentComAnnouncementSound = "/Audio/Corvax/Announcements/centcomm.ogg"; // Corvax-Announcements
 
+    public readonly TimeSpan coolDown = TimeSpan.FromSeconds(2); //ss220 chat unique
+    public const int MaximumLengthMsg = 5; //ss220 chat unique
+
     private bool _loocEnabled = true;
     private bool _deadLoocEnabled;
     private bool _critLoocEnabled;
@@ -88,6 +91,16 @@ public sealed partial class ChatSystem : SharedChatSystem
 
         SubscribeLocalEvent<GameRunLevelChangedEvent>(OnGameChange);
     }
+
+    // ss220 chat unique begin
+    public struct ChatUniqueStruct
+    {
+        public TimeSpan? lastMessageTimeSent;
+        public string? message;
+    }
+
+    public Dictionary<EntityUid, ChatUniqueStruct> ChatMsgUnique = new();
+    // ss220 chat unique end
 
     private void OnLoocEnabledChanged(bool val)
     {
@@ -238,6 +251,24 @@ public sealed partial class ChatSystem : SharedChatSystem
         // This can happen if the entire string is sanitized out.
         if (string.IsNullOrEmpty(message))
             return;
+
+        //ss220 chat unique begin
+        if (ChatMsgUnique.TryGetValue(source, out var chatStruct)
+            && chatStruct.message == message
+            && message.Length >= MaximumLengthMsg)
+        {
+            var curTime = _gameTiming.CurTime;
+            if (curTime - chatStruct.lastMessageTimeSent < coolDown)
+                return;
+
+            ChatMsgUnique[source] = new ChatUniqueStruct() { message = message, lastMessageTimeSent = curTime };
+        }
+        else
+        {
+            var curTime = _gameTiming.CurTime;
+            ChatMsgUnique[source] = new ChatUniqueStruct() { message = message, lastMessageTimeSent = curTime };
+        }
+        //ss220 chat unique end
 
         // This message may have a radio prefix, and should then be whispered to the resolved radio channel
         if (checkRadioPrefix)

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -99,7 +99,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         public string? message;
     }
 
-    public Dictionary<EntityUid, ChatUniqueStruct> ChatMsgUnique = new();
+    private Dictionary<EntityUid, ChatUniqueStruct> ChatMsgUnique = new();
     // ss220 chat unique end
 
     private void OnLoocEnabledChanged(bool val)

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -99,7 +99,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         public string? message;
     }
 
-    private Dictionary<EntityUid, ChatUniqueStruct> ChatMsgUnique = new();
+    public Dictionary<EntityUid, ChatUniqueStruct> ChatMsgUnique { get; private set;} = new();
     // ss220 chat unique end
 
     private void OnLoocEnabledChanged(bool val)


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Добавлена уникальность сообщений в чате. Теперь энтити может отправлять одинаковые сообщения раз в 2 секунды. Если сообщение имеет меньше 5 символом (для того, чтобы звать сб и т.д.), то оно не попадает под условие спама.  (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1310)

**Медиа**

https://github.com/user-attachments/assets/0a87f3b3-73bd-4285-89ef-08971db11660

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii

- add: Добавлена проверка на уникальность сообщения длиной 5 символов и более (КД между отправкой - 2 секунды).

