### PR TITLE
add: РИТЭГ теперь периодически теряет свой запас радиации

### DIFF
--- a/Content.Server/SS220/RadiationDecrease/RadiationDecreaseSystem.cs
+++ b/Content.Server/SS220/RadiationDecrease/RadiationDecreaseSystem.cs
@@ -1,0 +1,77 @@
+﻿using Content.Server.Power.Components;
+using Content.Shared.Radiation.Components;
+using Content.Shared.SS220.RadiationDecrease;
+using Robust.Shared.Timing;
+
+namespace Content.Server.SS220.RadiationDecrease;
+
+public sealed partial class RadiationDecreaseSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RadiationDecreaseComponent, ComponentInit>(OnCompInit);
+    }
+
+    private void OnCompInit(EntityUid uid, RadiationDecreaseComponent comp, ComponentInit args)
+    {
+        if (TryComp<RadiationSourceComponent>(uid, out var radSourceComponent) && radSourceComponent.Intensity != 0)
+        {
+            comp.Intensity = radSourceComponent.Intensity;
+        }
+        if (TryComp<PowerSupplierComponent>(uid, out var supplyComp) && supplyComp.MaxSupply != 0)
+        {
+            comp.Supply = supplyComp.MaxSupply;
+        }
+    }
+
+    public override void Update(float delta)
+    {
+        base.Update(delta);
+        var query = EntityQueryEnumerator<RadiationDecreaseComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (TryComp<RadiationSourceComponent>(uid, out var radSourceComponent) && radSourceComponent.Intensity != 0)
+            {
+                var decreasePerSecond = comp.Intensity / comp.TotalAliveTime;
+
+                var curTime = _gameTiming.CurTime;
+
+                if (curTime - comp.LastTimeDecreaseRad < comp.CoolDown)
+                {
+                    return;
+                }
+
+                comp.LastTimeDecreaseRad = curTime;
+                if (radSourceComponent.Intensity - decreasePerSecond < 0) // without if - crash Pow3r
+                {
+                    radSourceComponent.Intensity = 0;
+                    decreasePerSecond = 0;
+                }
+                radSourceComponent.Intensity -= decreasePerSecond;
+            }
+
+            if (TryComp<PowerSupplierComponent>(uid, out var powerSupply) && powerSupply.MaxSupply != 0)
+            {
+                var decreasePerSecond = comp.Supply / comp.TotalAliveTime;
+
+                var curTime = _gameTiming.CurTime;
+
+                if (curTime - comp.LastTimeDecreaseSupply < comp.CoolDown)
+                {
+                    return;
+                }
+
+                comp.LastTimeDecreaseSupply = curTime;
+                if (powerSupply.MaxSupply - decreasePerSecond < 0) // without if - crash Pow3r
+                {
+                    powerSupply.MaxSupply = 0;
+                    decreasePerSecond = 0;
+                }
+                powerSupply.MaxSupply -= decreasePerSecond;
+            }
+        }
+    }
+}

--- a/Content.Shared/SS220/RadiationDecrease/RadiationDecreaseComponent.cs
+++ b/Content.Shared/SS220/RadiationDecrease/RadiationDecreaseComponent.cs
@@ -1,0 +1,19 @@
+﻿namespace Content.Shared.SS220.RadiationDecrease;
+
+/// <summary>
+///     Decrease radiation per second in Damaged RTG
+/// </summary>
+[RegisterComponent]
+public sealed partial class RadiationDecreaseComponent : Component
+{
+    public readonly int TotalAliveTime = 1200; // 20 minutes
+
+    public readonly TimeSpan CoolDown = TimeSpan.FromSeconds(1f);
+
+    public TimeSpan LastTimeDecreaseRad = TimeSpan.Zero;
+    public TimeSpan LastTimeDecreaseSupply = TimeSpan.Zero;
+
+    public float Intensity = 0; // radiation capacity in RadiationSourceComponent
+    public float Supply = 0; // powersupp in PowerSupplierComponent
+
+}

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -125,7 +125,7 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Radiation: 0.3 #salv is supposed to have radiation hazards in the future
+        Radiation: 0.8 #salv is supposed to have radiation hazards in the future # ss220 rad fix 0.3 -> 0.8 (20%)
         Caustic: 0.8
         Stamina: 0.8
   - type: ClothingSpeedModifier

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
@@ -295,6 +295,7 @@
   - type: PowerMonitoringDevice
     sprite: Structures/Power/Generation/rtg.rsi
     state: rtg_damaged
+  - type: RadiationDecrease #ss220 damage rtg fix
   - type: RadiationSource # ideally only when opened.
     intensity: 2
   - type: Destructible


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Разрушенный РИТЭГ теперь периодически теряет свой запас радиации, а через 20 минут, он будет равен нулю.  (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1449)
Так же был пофикшен легкий скафандр утилизатора (порезали радиационный урон с 70% -> 20% P.S. согласовано с gogenych)

**Медиа**

https://github.com/user-attachments/assets/541d1504-7232-485e-8c9c-bce5cb46e27e



**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- add: РИТЭГ теперь периодически теряет свой запас радиации
- fix: У легкого скафандра утилизатора защита от радиации снижена до 20%
