### PR TITLE
Fuel generator fix

### DIFF
--- a/Content.Server/Power/Generator/GeneratorSystem.cs
+++ b/Content.Server/Power/Generator/GeneratorSystem.cs
@@ -114,6 +114,7 @@ public sealed class GeneratorSystem : SharedGeneratorSystem
                 multiplier * FixedPoint2.Epsilon.Float(),
                 availableReagent.Value);
 
+            entity.Comp.FractionalReagents[reagentId] = fractionalReagent;
             _solutionContainer.RemoveReagent(entity.Comp.Solution.Value, reagentId, FixedPoint2.FromCents(toRemove));
         }
     }


### PR DESCRIPTION
## Описание PR
По какой-то причине на нашем форке было сломано потребление топлива у портативных генераторов на сварочном топливе (`PortableGeneratorJrPacman`). По факту с репозитория оффов при мерже куда-то пропала одна строчка ([Строчка у оффов](https://github.com/space-wizards/space-station-14/blob/6a1efebb6a01a1636515de295405b7dfdbc08ffd/Content.Server/Power/Generator/GeneratorSystem.cs#L118), [Мерж](https://github.com/SerbiaStrong-220/space-station-14/commit/4a32152a53e946eaa2d72711ea7c12bc9286c8ab#diff-52892c54f1fac60945129dbe8ccedc2e33c9ac75e89a9b33122f36b6e6f252c1)).

**Медиа**

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl:
- fix: Портативный генератор М.И.Н.И.П.А.К.М.А.Н. теперь потребляет правильное количество топлива, тем самым работает дольше.
