### PR TITLE
Thief communicator set description fix

### DIFF
--- a/Resources/Locale/ru-RU/thief/backpack.ftl
+++ b/Resources/Locale/ru-RU/thief/backpack.ftl
@@ -43,7 +43,7 @@ thief-backpack-category-sleeper-description =
 thief-backpack-category-communicator-name = Набор связиста
 thief-backpack-category-communicator-description =
     Набор для радиолюбителей. Включает мастер-ключ шифрования
-    для всех радиоканалов станции, ручку Cybersun, портативный монитор экипажа,
+    для всех радиоканалов станции, ручку Cybersun,
     голосовую маску-хамелеон, и много денег для ведения бизнеса.
 thief-backpack-category-smuggler-name = Набор контрабандиста
 thief-backpack-category-smuggler-description =


### PR DESCRIPTION
## Описание PR
Исправлено описание "Набора связиста" в ящике воровских инструментов - удалено упоминание портативного монитора экипажа.

**Медиа**
![image](https://github.com/user-attachments/assets/2196a2c4-ffad-4044-a400-5e2dccfa5716)

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
remove: Убран "портативный монитор экипажа" с перечисления содержимого "Набора связиста".

:cl: Vuyko_Sheshych
