### PR TITLE
FIX emergency medipen loadout

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -39,6 +39,7 @@
     - id: ClothingMaskBreath
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # SS220 Revert deleted Medipen
     - id: Flare
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
@@ -87,6 +88,7 @@
     - id: ClothingMaskBreath
     - id: ExtendedEmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # SS220 Revert deleted Medipen
     - id: Flare
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
@@ -167,6 +169,7 @@
     - id: ClothingMaskGasSecurity
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # SS220 Revert deleted Medipen
     - id: Flare
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
@@ -216,6 +219,7 @@
     - id: ClothingMaskBreathMedical
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # SS220 Revert deleted Medipen
     - id: Flare
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
@@ -268,6 +272,7 @@
     - id: ClothingMaskBreath
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # SS220 Revert deleted Medipen
     - id: Flare
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
@@ -314,6 +319,7 @@
     - id: ClothingMaskGasSyndicate
     - id: ExtendedEmergencyNitrogenTankFilled
     - id: EmergencyMedipen
+    - id: SpaceMedipen # SS220 Revert deleted Medipen
     - id: Flare
     - id: FoodSnackNutribrick
     # Intentionally wrong picture on the box to mimic the NT one


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Теперь внутри N2 аварийных запасов лежит медипен (fix: https://discord.com/channels/1097181193939730453/1271485596161937431)

**Медиа**

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- fix: Исправлено непоявление космических медипенов в азотных аварийных запасах
