### PR TITLE
FIX stunbaton decrease energy on hit

### DIFF
--- a/Content.Server/Stunnable/Systems/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunbatonSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Item.ItemToggle;
 using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Popups;
 using Content.Shared.Stunnable;
+using Content.Shared.Throwing;
 using Content.Shared.Weapons.Melee.Events;
 
 namespace Content.Server.Stunnable.Systems
@@ -32,6 +33,8 @@ namespace Content.Server.Stunnable.Systems
             SubscribeLocalEvent<StunbatonComponent, ItemToggleActivateAttemptEvent>(TryTurnOn);
             SubscribeLocalEvent<StunbatonComponent, ItemToggledEvent>(ToggleDone);
             SubscribeLocalEvent<StunbatonComponent, ChargeChangedEvent>(OnChargeChanged);
+            SubscribeLocalEvent<StunbatonComponent, MeleeHitEvent>(OnEnergyDecrease); //ss220 stunbaton decrease energy fix
+            SubscribeLocalEvent<StunbatonComponent, ThrowDoHitEvent>(OnThrowEnergyDecrease); //ss220 stunbaton decrease energy fix
         }
 
         // SS220-Stunbaton-rework begin
@@ -113,5 +116,25 @@ namespace Content.Server.Stunnable.Systems
                 _itemToggle.TryDeactivate(entity.Owner, predicted: false);
             }
         }
+
+        //ss220 stunbaton decrease energy fix start
+        private void OnEnergyDecrease(Entity<StunbatonComponent> entity, ref MeleeHitEvent args)
+        {
+            if (TryComp<BatteryComponent>(entity.Owner, out var batteryComponent) && _itemToggle.IsActivated(entity.Owner))
+            {
+                _battery.TryUseCharge(entity.Owner, entity.Comp.EnergyPerUse, batteryComponent);
+            }
+
+        }
+
+        private void OnThrowEnergyDecrease(Entity<StunbatonComponent> entity, ref ThrowDoHitEvent args)
+        {
+            if (TryComp<BatteryComponent>(entity.Owner, out var batteryComponent) && _itemToggle.IsActivated(entity.Owner))
+            {
+                _battery.TryUseCharge(entity.Owner, entity.Comp.EnergyPerUse, batteryComponent);
+            }
+        }
+        //ss220 stunbaton decrease energy fix end
+
     }
 }


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Станбатон теперь станит когда бьешь ПКМ и при кидании в ентити (fix https://github.com/SerbiaStrong-220/space-station-14/issues/1597)

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- fix: Шок-дубинка теперь тратит свои заряды при кидании и широкой атаке
