### PR TITLE
FIX: Name after cloning zombie

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.Mind;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.NameModifier.Components;
 using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.Popups;
 using Content.Shared.Tag;
@@ -323,6 +324,15 @@ namespace Content.Server.Zombies
             }
             _humanoidAppearance.SetSkinColor(target, zombiecomp.BeforeZombifiedSkinColor, false);
             _bloodstream.ChangeBloodReagent(target, zombiecomp.BeforeZombifiedBloodReagent);
+
+            //SS220 ZOMBIE NAME FIX START
+            var targetModifierComponent = AddComp<NameModifierComponent>(target);
+
+            if (TryComp<NameModifierComponent>(source, out var sourceModifierComponent))
+            {
+                targetModifierComponent.BaseName = sourceModifierComponent.BaseName;
+            }
+            //SS220 ZOMBIE NAME FIX END
 
             _nameMod.RefreshNameModifiers(target);
             return true;

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -325,7 +325,7 @@ namespace Content.Server.Zombies
             _humanoidAppearance.SetSkinColor(target, zombiecomp.BeforeZombifiedSkinColor, false);
             _bloodstream.ChangeBloodReagent(target, zombiecomp.BeforeZombifiedBloodReagent);
 
-            //SS220 ZOMBIE NAME FIX START
+            //SS220 ZOMBIE NAME FIX START (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1651 && https://github.com/SerbiaStrong-220/space-station-14/issues/1567)
             var targetModifierComponent = AddComp<NameModifierComponent>(target);
 
             if (TryComp<NameModifierComponent>(source, out var sourceModifierComponent))

--- a/Content.Shared/NameModifier/Components/NameModifierComponent.cs
+++ b/Content.Shared/NameModifier/Components/NameModifierComponent.cs
@@ -16,5 +16,6 @@ public sealed partial class NameModifierComponent : Component
     /// The entity's name without any modifiers applied.
     /// </summary>
     [DataField, AutoNetworkedField]
+    [Access(Other = AccessPermissions.ReadWrite)] // ss220 access to zombie name fix
     public string BaseName = string.Empty;
 }


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Имя зомби после клонерки было неправильным.
(fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1651)
(fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1567)

**Медиа**


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- fix: Исправлены имена после клонирования зомби
