### PR TITLE
Atmos Holoprojector Buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -58,7 +58,7 @@
   components:
   - type: HolosignProjector
     signProto: HoloFan
-    chargeUse: 120
+    chargeUse: 110 #SS220 holo buff. 120 -> 110. 6 charges
   - type: Sprite
     sprite: Objects/Devices/Holoprojectors/atmos.rsi
     state: icon

--- a/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
@@ -32,6 +32,11 @@
   name: holofan
   description: A barrier of hard light that blocks air, but nothing else.
   components:
+  #SS220 atmos holo buff, physics start
+  - type: Physics
+    bodyType: Static
+    canCollide: true
+  #SS220 atmos holo buff, physics end
   - type: Sprite
     sprite: Structures/Holo/holofan.rsi
     state: icon
@@ -41,10 +46,18 @@
         shape:
           !type:PhysShapeAabb
             bounds: "-0.5,-0.5,0.5,0.5"
+        #SS220 Atmos holo buff start
+        mask:
+        - TableMask
+        layer:
+        - TableLayer
+        #SS220 Atmos holo end
   - type: TimedDespawn
-    lifetime: 180
+    lifetime: 10800 #3 hours IRL. SS220 Atmos Holo Buff
   - type: Airtight
     noAirWhenFullyAirBlocked: false
+  - type: Climbable #SS220 Atmos holo buff
+  - type: Clickable #SS220 Atmos holo buff
 
 - type: entity
   id: HolosignSecurity


### PR DESCRIPTION
## Описание PR
WYCI бафф атмос голопроекторов по [трекеру](https://discord.com/channels/1097181193939730453/1258478629612945448)
![image](https://github.com/user-attachments/assets/7b7d2710-eed9-47c9-acdb-dcbfa099c9b8)


**Медиа**
https://youtu.be/EG7aU477YS4
Видео уже месяц, но я проверил еще раз. Работает как и показано на медиа.

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
1. Одна проекция длится 3 часа. Придумать как сделать их реально бесконечными я не смог.
2. Уменьшен расход батареи. Теперь со средней батареей(вставлена раундстарт) можно поставить 6 проекций, а не 4.
3. Для прохождения надо перелазить, как барьер СБ.

:cl:
- tweak: Изменены атмос голопроекции!