### PR TITLE
WhitelistFailPopup bugfix

### DIFF
--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -209,7 +209,7 @@ namespace Content.Shared.Containers.ItemSlots
                     continue;
 
                 slots.Add(slot);
-                break;
+                break; //ss220 WhitelistFailPopup bugfix https://github.com/SerbiaStrong-220/space-station-14/pull/1702
             }
 
             if (slots.Count == 0)

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -209,6 +209,7 @@ namespace Content.Shared.Containers.ItemSlots
                     continue;
 
                 slots.Add(slot);
+                break;
             }
 
             if (slots.Count == 0)


### PR DESCRIPTION
## Описание PR
Исправление бага из-за которого при попытке вставить вещь которая может находиться в раздатчике появлялась надпись, что туда нельзя положить данный предмет.

Суть бага в том, что при попытке положить предмет вызывается функция проверки CanInsert() в ItemSlotsSystem и один из слотов в которые проверяются является слот для емкости(мензурки, стакана и т.д.), он соответственно не проходит проверку и вызывает popup. 

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
 - fix: Исправлено появление надписи взаимодействия с раздатчиком