### PR TITLE
Added overcharge field to BatteryComponent

### DIFF
--- a/Content.Server/Power/Components/BatteryComponent.cs
+++ b/Content.Server/Power/Components/BatteryComponent.cs
@@ -35,6 +35,16 @@ namespace Content.Server.Power.Components
         /// </summary>
         [DataField]
         public float PricePerJoule = 0.0001f;
+
+        //SS220-smes-overcharge begin
+        /// <summary>
+        /// Use this if you set current charge more than max charge.
+        /// Will be false if current charge drops below than max charge.
+        /// Also blocks getting more charge when true.
+        /// </summary>
+        [DataField]
+        public bool IsOvercharged = false;
+        //SS220-smes-overcharge end
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->
Была задача добавить овечардж СМЭСам. Вследствии, овечардж теперь можно дать любой батарейке.
На данный момент батарейку в оверчарже нельзя заряжать, только тратить. Как только заряд станет равным или меньше максимальному, то состояние оверчарджа снимается.
**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->
![image](https://github.com/user-attachments/assets/08566860-7312-41ca-9a0c-93617580e6d6)
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->
no cl