### PR TITLE
Fix: Отсутствие резиновых боеприпасов в крафте

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -757,14 +757,19 @@
       - Handcuffs
       - MagazineBoxLightRifle
       - MagazineBoxLightRiflePractice
+      - MagazineBoxLightRifleRubber #SS220-fix Magazine Pistol Rubber Lathe (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
       - MagazineBoxMagnum
       - MagazineBoxMagnumPractice
+      - MagazineBoxMagnumRubber #SS220-fix Magazine Pistol Rubber Lathe (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
       - MagazineBoxPistol
       - MagazineBoxPistolPractice
+      - MagazineBoxPistolRubber #SS220-fix Magazine Pistol Rubber Lathe (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
       - MagazineBoxRifle
       - MagazineBoxRiflePractice
+      - MagazineBoxRifleRubber #SS220-fix Magazine Pistol Rubber Lathe (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
       - MagazineLightRifle
       - MagazineLightRifleEmpty
+      - MagazineLightRifleRubber #SS220-fix Magazine Pistol Rubber Lathe (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
       - MagazinePistol
       - MagazinePistolEmpty
       - MagazinePistolRubber #SS220-fix Magazine Pistol Rubber Lathe (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
@@ -774,12 +779,14 @@
       - MagazinePistolSubMachineGunTopMountedEmpty
       - MagazineRifle
       - MagazineRifleEmpty
+      - MagazineRifleRubber #SS220-fix Magazine Pistol Rubber Lathe (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
       - MagazineShotgun
       - MagazineShotgunEmpty
       - MagazineShotgunSlug
       - RiotShield
       - SpeedLoaderMagnum
       - SpeedLoaderMagnumEmpty
+      - SpeedLoaderMagnumRubber #SS220-fix Magazine Pistol Rubber Lathe (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
       - Stunbaton
       - TargetClown
       - TargetHuman

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -767,6 +767,7 @@
       - MagazineLightRifleEmpty
       - MagazinePistol
       - MagazinePistolEmpty
+      - MagazinePistolRubber #SS220-fix Magazine Pistol Rubber Lathe (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
       - MagazinePistolSubMachineGun
       - MagazinePistolSubMachineGunEmpty
       - MagazinePistolSubMachineGunTopMounted

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -283,6 +283,15 @@
   materials:
     Steel: 240
 
+- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
+  id: MagazineBoxMagnumRubber
+  result: MagazineBoxMagnumRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 350
+    Plastic: 300 #SS220-fix Magazine Pistol Rubber Lathe end
+
 - type: latheRecipe
   id: MagazineRifleEmpty
   result: MagazineRifleEmpty
@@ -299,6 +308,14 @@
   materials:
     Steel: 475
 
+- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
+  id: MagazineRifleRubber
+  result: MagazineRifleRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 175
+    Plastic: 300 #SS220-fix Magazine Pistol Rubber Lathe end
 
 - type: latheRecipe
   id: MagazineRiflePractice
@@ -343,6 +360,15 @@
   materials:
     Steel: 565
 
+- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
+  id: MagazineLightRifleRubber
+  result: MagazineLightRifleRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 175
+    Plastic: 300 #SS220-fix Magazine Pistol Rubber Lathe end
+
 - type: latheRecipe
   id: MagazineLightRiflePractice
   result: MagazineLightRiflePractice
@@ -379,6 +405,15 @@
   materials:
     Steel: 750
 
+- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
+  id: MagazineBoxRifleRubber
+  result: MagazineBoxRifleRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 350
+    Plastic: 600 #SS220-fix Magazine Pistol Rubber Lathe end
+
 - type: latheRecipe
   id: MagazineBoxLightRifle
   result: MagazineBoxLightRifle
@@ -386,6 +421,15 @@
   completetime: 5
   materials:
     Steel: 900
+
+- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
+  id: MagazineBoxLightRifleRubber
+  result: MagazineBoxLightRifleRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 350
+    Plastic: 600 #SS220-fix Magazine Pistol Rubber Lathe end
 
 - type: latheRecipe
   id: BoxLethalshot
@@ -420,6 +464,15 @@
   completetime: 5
   materials:
     Steel: 50
+
+- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
+  id: SpeedLoaderMagnumRubber
+  result: SpeedLoaderMagnumRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 175
+    Plastic: 150 #SS220-fix Magazine Pistol Rubber Lathe end
 
 - type: latheRecipe
   id: SpeedLoaderMagnum
@@ -556,6 +609,15 @@
   completetime: 5
   materials:
     Steel: 300
+
+- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
+  id: MagazineBoxPistolRubber
+  result: MagazineBoxPistolRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 350
+    Plastic: 300 #SS220-fix Magazine Pistol Rubber Lathe end
 
 - type: latheRecipe
   id: MagazineBoxMagnumPractice

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -199,6 +199,15 @@
   materials:
     Steel: 145
 
+- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
+  id: MagazinePistolRubber
+  result: MagazinePistolRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 145
+    Plastic: 145 #SS220-fix Magazine Pistol Rubber Lathe end
+
 - type: latheRecipe
   id: MagazinePistolPractice
   result: MagazinePistolPractice

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -290,6 +290,7 @@
   materials:
     Steel: 475
 
+
 - type: latheRecipe
   id: MagazineRiflePractice
   result: MagazineRiflePractice

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -199,15 +199,6 @@
   materials:
     Steel: 145
 
-- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
-  id: MagazinePistolRubber
-  result: MagazinePistolRubber
-  category: Ammo
-  completetime: 5
-  materials:
-    Steel: 145
-    Plastic: 145 #SS220-fix Magazine Pistol Rubber Lathe end
-
 - type: latheRecipe
   id: MagazinePistolPractice
   result: MagazinePistolPractice
@@ -283,15 +274,6 @@
   materials:
     Steel: 240
 
-- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
-  id: MagazineBoxMagnumRubber
-  result: MagazineBoxMagnumRubber
-  category: Ammo
-  completetime: 5
-  materials:
-    Steel: 350
-    Plastic: 300 #SS220-fix Magazine Pistol Rubber Lathe end
-
 - type: latheRecipe
   id: MagazineRifleEmpty
   result: MagazineRifleEmpty
@@ -307,15 +289,6 @@
   completetime: 5
   materials:
     Steel: 475
-
-- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
-  id: MagazineRifleRubber
-  result: MagazineRifleRubber
-  category: Ammo
-  completetime: 5
-  materials:
-    Steel: 175
-    Plastic: 300 #SS220-fix Magazine Pistol Rubber Lathe end
 
 - type: latheRecipe
   id: MagazineRiflePractice
@@ -360,15 +333,6 @@
   materials:
     Steel: 565
 
-- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
-  id: MagazineLightRifleRubber
-  result: MagazineLightRifleRubber
-  category: Ammo
-  completetime: 5
-  materials:
-    Steel: 175
-    Plastic: 300 #SS220-fix Magazine Pistol Rubber Lathe end
-
 - type: latheRecipe
   id: MagazineLightRiflePractice
   result: MagazineLightRiflePractice
@@ -405,15 +369,6 @@
   materials:
     Steel: 750
 
-- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
-  id: MagazineBoxRifleRubber
-  result: MagazineBoxRifleRubber
-  category: Ammo
-  completetime: 5
-  materials:
-    Steel: 350
-    Plastic: 600 #SS220-fix Magazine Pistol Rubber Lathe end
-
 - type: latheRecipe
   id: MagazineBoxLightRifle
   result: MagazineBoxLightRifle
@@ -421,15 +376,6 @@
   completetime: 5
   materials:
     Steel: 900
-
-- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
-  id: MagazineBoxLightRifleRubber
-  result: MagazineBoxLightRifleRubber
-  category: Ammo
-  completetime: 5
-  materials:
-    Steel: 350
-    Plastic: 600 #SS220-fix Magazine Pistol Rubber Lathe end
 
 - type: latheRecipe
   id: BoxLethalshot
@@ -464,15 +410,6 @@
   completetime: 5
   materials:
     Steel: 50
-
-- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
-  id: SpeedLoaderMagnumRubber
-  result: SpeedLoaderMagnumRubber
-  category: Ammo
-  completetime: 5
-  materials:
-    Steel: 175
-    Plastic: 150 #SS220-fix Magazine Pistol Rubber Lathe end
 
 - type: latheRecipe
   id: SpeedLoaderMagnum
@@ -609,15 +546,6 @@
   completetime: 5
   materials:
     Steel: 300
-
-- type: latheRecipe #SS220-fix Magazine Pistol Rubber Lathe start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1799)
-  id: MagazineBoxPistolRubber
-  result: MagazineBoxPistolRubber
-  category: Ammo
-  completetime: 5
-  materials:
-    Steel: 350
-    Plastic: 300 #SS220-fix Magazine Pistol Rubber Lathe end
 
 - type: latheRecipe
   id: MagazineBoxMagnumPractice

--- a/Resources/Prototypes/SS220/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/SS220/Recipes/Lathes/security.yml
@@ -1,0 +1,71 @@
+- type: latheRecipe
+  id: MagazinePistolRubber
+  result: MagazinePistolRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 145
+    Plastic: 145
+
+- type: latheRecipe
+  id: MagazineBoxMagnumRubber
+  result: MagazineBoxMagnumRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 350
+    Plastic: 300
+
+- type: latheRecipe
+  id: MagazineRifleRubber
+  result: MagazineRifleRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 175
+    Plastic: 300
+
+- type: latheRecipe
+  id: MagazineLightRifleRubber
+  result: MagazineLightRifleRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 175
+    Plastic: 300
+
+- type: latheRecipe
+  id: MagazineBoxRifleRubber
+  result: MagazineBoxRifleRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 350
+    Plastic: 600
+
+- type: latheRecipe
+  id: MagazineBoxLightRifleRubber
+  result: MagazineBoxLightRifleRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 350
+    Plastic: 600
+
+- type: latheRecipe
+  id: SpeedLoaderMagnumRubber
+  result: SpeedLoaderMagnumRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 175
+    Plastic: 150
+
+- type: latheRecipe
+  id: MagazineBoxPistolRubber
+  result: MagazineBoxPistolRubber
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 350
+    Plastic: 300


### PR DESCRIPTION
## Описание PR
Отсутствие резиновых боеприпасов в крафте (fix: #1799)

В охранном Техфабе можно раундстартом печатать резиновые боеприпасы
Не знаю какие компоненты и сколько надо использовать для пистолетного магазина (MagazinePistolRubber), поэтому пока 1,45 стали и пластика
Нужно ли как то указать этот PR в Issues?

Рецепты взяты из PR: https://github.com/space-wizards/space-station-14/pull/26470

**Медиа**
![image](https://github.com/user-attachments/assets/4df5b32f-59c9-46ce-826c-37b9f38f4278)

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl: IlyaElDunaev

- fix: В охранный Техфаб добавлены рецепты резиновых боеприпасов
