### PR TITLE
FIX: Nuke declaration war spam

### DIFF
--- a/Content.Client/NukeOps/WarDeclaratorBoundUserInterface.cs
+++ b/Content.Client/NukeOps/WarDeclaratorBoundUserInterface.cs
@@ -41,5 +41,12 @@ public sealed class WarDeclaratorBoundUserInterface : BoundUserInterface
         var maxLength = _cfg.GetCVar(CCVars.ChatMaxAnnouncementLength);
         var msg = SharedChatSystem.SanitizeAnnouncement(message, maxLength);
         SendMessage(new WarDeclaratorActivateMessage(msg));
+
+        //ss220 SPAM Button NukeDecWar fix start
+        if (_window != null)
+        {
+            _window.WarButton.Disabled = true;
+        }
+        //ss220 SPAM Button NukeDecWar fix end
     }
 }


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Теперь объявить войну можно один раз, а не как раньше, взять да заспамить (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1565)

**Медиа**
Было:
![image](https://github.com/user-attachments/assets/44b38d64-3da8-48e2-b776-98c88452eb44)
Стало:
![image](https://github.com/user-attachments/assets/927de84e-61ca-4005-8d96-e30677b8c453)


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлением по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- fix: Исправлен спам объявлением войны
