### PR TITLE
FIX: Dark Repear babax damage

### DIFF
--- a/Content.Shared/Explosion/Components/ExplosionResistanceComponent.cs
+++ b/Content.Shared/Explosion/Components/ExplosionResistanceComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Explosion.EntitySystems;
+using Content.Shared.SS220.DarkReaper;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
 using Robust.Shared.GameStates;
 
@@ -21,6 +22,7 @@ public sealed partial class ExplosionResistanceComponent : Component
     ///     The explosive resistance coefficient, This fraction is multiplied into the total resistance.
     /// </summary>
     [DataField("damageCoefficient")]
+    [Access(typeof(SharedExplosionSystem), typeof(SharedDarkReaperSystem))] //ss220 access for DarkReaper
     public float DamageCoefficient = 1;
 
     /// <summary>

--- a/Content.Shared/SS220/DarkReaper/DarkReaperSharedSystem.cs
+++ b/Content.Shared/SS220/DarkReaper/DarkReaperSharedSystem.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using Content.Shared.Actions;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
+using Content.Shared.Explosion.Components;
 using Content.Shared.Humanoid;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
@@ -370,6 +371,12 @@ public abstract class SharedDarkReaperSystem : EntitySystem
         if (isMaterial)
         {
             _tag.AddTag(uid, "DoorBumpOpener");
+
+            if (TryComp<ExplosionResistanceComponent>(uid, out var explosionResistanceComponent))
+            {
+                explosionResistanceComponent.DamageCoefficient = 1f; //full damage
+            }
+
             if (HasComp<NpcFactionMemberComponent>(uid))
             {
                 _npcFaction.ClearFactions(uid);
@@ -381,6 +388,12 @@ public abstract class SharedDarkReaperSystem : EntitySystem
             _tag.RemoveTag(uid, "DoorBumpOpener");
             comp.StunScreamStart = null;
             comp.MaterializedStart = null;
+
+            if (TryComp<ExplosionResistanceComponent>(uid, out var explodeComponent))
+            {
+                explodeComponent.DamageCoefficient = 0f; // full resistance
+            }
+
             if (HasComp<NpcFactionMemberComponent>(uid))
             {
                 _npcFaction.ClearFactions(uid);

--- a/Resources/Prototypes/SS220/DemonRofler/mob.yml
+++ b/Resources/Prototypes/SS220/DemonRofler/mob.yml
@@ -30,6 +30,7 @@
   - type: AntiRottingContainer
   - type: RadiationBlockingContainer
     resistance: 5
+  - type: ExplosionResistance
 
   # Visuals and appearance
   - type: Sprite


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Темный жнец получал дамаг в астрале от взрывов (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1656)

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлением по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- fix: Тёмный жнец больше не получает урон от взрыва в астральном мире
