### PR TITLE
FIX: Same codewords for all traitors

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -61,15 +61,17 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
     private void SetCodewords(TraitorRuleComponent component)
     {
         //ss220 same codewords for all traitors start
-        if (_gameTicker.IsGameRuleAdded<TraitorRuleComponent>())
+        if (!_gameTicker.IsGameRuleAdded<TraitorRuleComponent>())
         {
-            var ruleEnts = _gameTicker.GetAddedGameRules();
-            foreach (var ruleEnt in ruleEnts)
+            return;
+        }
+
+        var ruleEnts = _gameTicker.GetAddedGameRules();
+        foreach (var ruleEnt in ruleEnts)
+        {
+            if (TryComp<TraitorRuleComponent>(ruleEnt, out var traitorComp))
             {
-                if (TryComp(ruleEnt, out TraitorRuleComponent? traitorComp))
-                {
-                    component.Codewords = traitorComp.Codewords.Contains(null) ? GenerateTraitorCodewords(component) : traitorComp.Codewords;
-                }
+                component.Codewords = traitorComp.Codewords.Contains(null) ? GenerateTraitorCodewords(component) : traitorComp.Codewords;
             }
         }
         //ss220 same codewords for all traitors end

--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -36,6 +36,7 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
     [Dependency] private readonly SharedRoleSystem _roleSystem = default!;
     [Dependency] private readonly SharedJobSystem _jobs = default!;
     [Dependency] private readonly SharedRoleCodewordSystem _roleCodewordSystem = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!;
 
     public override void Initialize()
     {
@@ -59,7 +60,19 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
 
     private void SetCodewords(TraitorRuleComponent component)
     {
-        component.Codewords = GenerateTraitorCodewords(component);
+        //ss220 same codewords for all traitors start
+        if (_gameTicker.IsGameRuleAdded<TraitorRuleComponent>())
+        {
+            var ruleEnts = _gameTicker.GetAddedGameRules();
+            foreach (var ruleEnt in ruleEnts)
+            {
+                if (TryComp(ruleEnt, out TraitorRuleComponent? traitorComp))
+                {
+                    component.Codewords = traitorComp.Codewords.Contains(null) ? GenerateTraitorCodewords(component) : traitorComp.Codewords;
+                }
+            }
+        }
+        //ss220 same codewords for all traitors end
     }
 
     public string[] GenerateTraitorCodewords(TraitorRuleComponent component)


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Для всех антагов одинаковые кодовые слова (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1174)

**Медиа**


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлением по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- fix: Исправлены разные кодовые слова у предателей
