### PR TITLE
Plastic flaps collision fix (make conveyors great again)

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -53,7 +53,11 @@ public enum CollisionGroup
     ConveyorMask = Impassable | MidImpassable | LowImpassable | DoorPassable,
 
     // Crates
-    CrateMask = Impassable | HighImpassable | LowImpassable,
+    // SS220 Plastic Flaps Collision Fix begin
+    //CrateMask = Impassable | HighImpassable | LowImpassable,
+    // Why: not deleted for compatibility with wizards changes 
+    CrateMask = MachineMask,
+    // SS220 Plastic Flaps Collision Fix end
 
     // Tables that SmallMobs can go under
     TableMask = Impassable | MidImpassable,
@@ -73,7 +77,11 @@ public enum CollisionGroup
 
     // Soap, spills
     SlipLayer = MidImpassable | LowImpassable,
-    ItemMask = Impassable | HighImpassable,
+    // SS220 Plastic Flaps Collision Fix begin
+    //ItemMask = Impassable | HighImpassable,
+    // Why: plastic flaps moved to HighImpassible layer, and items should be able to pass
+    ItemMask = Impassable,
+    // SS220 Plastic Flaps Collision Fix end
     ThrownItem = Impassable | HighImpassable | BulletImpassable,
     WallLayer = Opaque | Impassable | HighImpassable | MidImpassable | LowImpassable | BulletImpassable | InteractImpassable,
     GlassLayer = Impassable | HighImpassable | MidImpassable | LowImpassable | BulletImpassable | InteractImpassable,

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/base_structuretanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/base_structuretanks.yml
@@ -19,7 +19,10 @@
         mask:
         - MachineMask
         layer:
-        - WallLayer
+        # SS220 Plastic Flaps Collision Fix begin
+        #- WallLayer
+        - MachineLayer
+        # SS220 Plastic Flaps Collision Fix end
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic

--- a/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
+++ b/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
@@ -23,7 +23,10 @@
         mask:
         - Impassable
         layer:
-        - MidImpassable
+        # SS220 Plastic Flaps Collision Fix begin
+        #- MidImpassable
+        - HighImpassable
+        # SS220 Plastic Flaps Collision Fix end
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Metallic
@@ -70,7 +73,10 @@
         - Impassable
         layer:
         - Opaque
-        - MidImpassable
+        # SS220 Plastic Flaps Collision Fix begin
+        #- MidImpassable
+        - HighImpassable
+        # SS220 Plastic Flaps Collision Fix end
   - type: Occluder
   - type: Construction
     graph: PlasticFlapsGraph


### PR DESCRIPTION
## Описание PR
Исправлены слои и маски коллизий для некоторых объектов чтобы обеспечить прохождение ими пластиковых шторок согласно [трекеру](https://discord.com/channels/1097181193939730453/1272595221523333241). 

Конкретно:
- **Шторки**: до этого блокировали `MidImpassable`, теперь блокируют `HighImpassable`. Это означает, что только высокие объекты по типу гуманоидных кукол не могут их пройти.
- **Ящики**: до этого пропускились шторками и занимали (кроме прочих) `HighImpassable`, чтобы проходить теперь назначена маска `MachineMask`, которая используется всякими напольными объектами.
- **Резервуары воды/топлива**: почему-то стояли на слое стен, то есть блокировали вообще всё что можно, в том числе бросание предметов сквозь, переместил их на `MachineLayer`, соответственно коллизии как у ящика.
- **Предметы**:  блокировались `Impassable` и `HighImpassable`, зачем `HighImpassable`? Убрал :gigachad:.

Из-за того, что данные изменения затрагивают большое количество объектов, оно может сломать что-то другое, так что данный PR в таком случае может быть главным подозреваемым.

**Медиа**

*(не обращайте внимание на то как там в конце предметы якобы отскакивают от стола, там оказывается невидимый объект)*

https://github.com/user-attachments/assets/57910b74-f07f-4174-8ed3-029f29772bdb


**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- tweak: Резервуары, шкафы, генераторы и многое другое теперь может проходить сквозь пластиковые шторки.
