### PR TITLE
Plastic Flaps Collision Fix Again

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -48,16 +48,15 @@ public enum CollisionGroup
     LargeMobLayer = Opaque | HighImpassable | MidImpassable | LowImpassable | BulletImpassable,
 
     // Machines, computers
-    MachineMask = Impassable | MidImpassable | LowImpassable,
+    // SS220 Plastic Flaps Collision Fix Again begin
+    //MachineMask = Impassable | MidImpassable | LowImpassable,
+    MachineMask = Impassable | HighImpassable | LowImpassable,
+    // SS220 Plastic Flaps Collision Fix Again end
     MachineLayer = Opaque | MidImpassable | LowImpassable | BulletImpassable,
     ConveyorMask = Impassable | MidImpassable | LowImpassable | DoorPassable,
 
     // Crates
-    // SS220 Plastic Flaps Collision Fix begin
-    //CrateMask = Impassable | HighImpassable | LowImpassable,
-    // Why: not deleted for compatibility with wizards changes 
-    CrateMask = MachineMask,
-    // SS220 Plastic Flaps Collision Fix end
+    CrateMask = Impassable | HighImpassable | LowImpassable,
 
     // Tables that SmallMobs can go under
     TableMask = Impassable | MidImpassable,
@@ -77,11 +76,7 @@ public enum CollisionGroup
 
     // Soap, spills
     SlipLayer = MidImpassable | LowImpassable,
-    // SS220 Plastic Flaps Collision Fix begin
-    //ItemMask = Impassable | HighImpassable,
-    // Why: plastic flaps moved to HighImpassible layer, and items should be able to pass
-    ItemMask = Impassable,
-    // SS220 Plastic Flaps Collision Fix end
+    ItemMask = Impassable | HighImpassable,
     ThrownItem = Impassable | HighImpassable | BulletImpassable,
     WallLayer = Opaque | Impassable | HighImpassable | MidImpassable | LowImpassable | BulletImpassable | InteractImpassable,
     GlassLayer = Impassable | HighImpassable | MidImpassable | LowImpassable | BulletImpassable | InteractImpassable,

--- a/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
+++ b/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
@@ -23,10 +23,7 @@
         mask:
         - Impassable
         layer:
-        # SS220 Plastic Flaps Collision Fix begin
-        #- MidImpassable
-        - HighImpassable
-        # SS220 Plastic Flaps Collision Fix end
+        - MidImpassable
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Metallic
@@ -73,10 +70,7 @@
         - Impassable
         layer:
         - Opaque
-        # SS220 Plastic Flaps Collision Fix begin
-        #- MidImpassable
-        - HighImpassable
-        # SS220 Plastic Flaps Collision Fix end
+        - MidImpassable
   - type: Occluder
   - type: Construction
     graph: PlasticFlapsGraph


### PR DESCRIPTION
## Описание PR
Исправляем предыдущую попытку фикса пластиковых шторок конвейеров (PR #1911), после него предметы смогли проходить сквозь закрытые двери.

В этот раз я вернул почти всё как было, и заменил у `MachineMask` `MidImpassable` на `HighImpassable`, чтобы тот мог проходить сквозь `MidImpassable` шторок (по сути, приравнял их к маске сундуков у оффов). Также изменение слоя резервуаров с жидкостью остаётся в силе с прошлого PR.

**Медиа**

https://github.com/user-attachments/assets/a9049dbf-9def-449f-981d-8d308148902b


**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl:
- fix: Предметы больше не проходят сквозь закрытые шлюзы.
