### PR TITLE
Map rendering crash fix

### DIFF
--- a/Content.MapRenderer/Painters/EntityData.cs
+++ b/Content.MapRenderer/Painters/EntityData.cs
@@ -1,4 +1,4 @@
-using Robust.Client.GameObjects;
+﻿using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
 
 namespace Content.MapRenderer.Painters;

--- a/Content.MapRenderer/Painters/EntityData.cs
+++ b/Content.MapRenderer/Painters/EntityData.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Client.GameObjects;
+using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
 
 namespace Content.MapRenderer.Painters;
@@ -12,4 +12,7 @@ public readonly record struct EntityData(EntityUid Owner, SpriteComponent Sprite
     public readonly float X = X;
 
     public readonly float Y = Y;
+
+    public readonly MetaDataComponent MetaData { get; init; } // SS220 Map Rendering Crash Fix
+    public readonly System.Numerics.Vector2 LocalPosition { get; init; } // SS220 Map Rendering Crash Fix
 }

--- a/Content.MapRenderer/Painters/EntityPainter.cs
+++ b/Content.MapRenderer/Painters/EntityPainter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;

--- a/Content.MapRenderer/Painters/EntityPainter.cs
+++ b/Content.MapRenderer/Painters/EntityPainter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
@@ -56,7 +56,17 @@ public sealed class EntityPainter
             return;
         }
 
-        var worldRotation = xformSystem.GetWorldRotation(entity.Owner);
+        // SS220 Map Rendering Crash Fix start
+        //var worldRotation = xformSystem.GetWorldRotation(entity.Owner);
+        if (!_sEntityManager.TryGetComponent<TransformComponent>(entity.Owner, out var xform))
+        {
+            Console.WriteLine(
+                $"{nameof(TransformComponent)} can not be found on entity at ({entity.X}, {entity.Y}) global position, {entity.LocalPosition} local position, " +
+                $"with {entity.Sprite.BaseRSI?.Path} RSI, prototype id '{entity.MetaData.EntityPrototype?.ID}', it is probably already destroyed, skipping.");
+            return;
+        }
+        var worldRotation = xformSystem.GetWorldRotation(xform);
+        // SS220 Map Rendering Crash Fix end
         foreach (var layer in entity.Sprite.AllLayers)
         {
             if (!layer.Visible)

--- a/Content.MapRenderer/Painters/GridPainter.cs
+++ b/Content.MapRenderer/Painters/GridPainter.cs
@@ -90,7 +90,14 @@ namespace Content.MapRenderer.Painters
                     var position = transform.LocalPosition;
 
                     var (x, y) = TransformLocalPosition(position, grid);
-                    var data = new EntityData(serverEntity, sprite, x, y);
+                    // SS220 Map Rendering Crash Fix start
+                    //var data = new EntityData(serverEntity, sprite, x, y)
+                    var data = new EntityData(serverEntity, sprite, x, y)
+                    {
+                        MetaData = _sEntityManager.GetComponent<MetaDataComponent>(serverEntity),
+                        LocalPosition = position,
+                    };
+                    // SS220 Map Rendering Crash Fix end
 
                     components.GetOrAdd(transform.GridUid.Value, _ => new List<EntityData>()).Add(data);
                 }


### PR DESCRIPTION
## Описание PR
Content.MapRenderer крашился при попытке отрисовать объект, который был удалён (например, эффекты, которые удаляются спустя N секунд), без каких либо полезных наводок на то, какой это объект. Теперь он будет пропускать такой объект и выводить его RSI, Prototype Id и Local Position чтобы его можно было найти в файле карты.

**Медиа**

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

no cl
