### PR TITLE
VendoAmmo Nerf Spawn Quatity

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -154,6 +154,7 @@
   description: An overwhelming amount of ancient patriotism washes over you just by looking at the machine.
   components:
   - type: VendingMachine
+    initialStockQuality: 0.33 # SS220 AmmoVend Nerf quantitiy spawn ammo
     pack: AmmoVendInventory
     offState: off
     brokenState: broken


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Вводит на объект `ПулеМат` к компоненте `VendingMachine` след. значения и параметр `initialStockQuality: 0.33` - что занижают количество доступных товаров в Торговом автомате патронов при его спавне. Создано с целью поддержания общей игровой условности торговых автоматов, а также для небольшого балансного введения, в связи с экспериментальным введением его на карте Astro.

**Медиа**
Отсутствуют

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- tweak: В ПулеМате теперь будет недоставать 2/3 позиций.
