### PR TITLE
Mark 1984 cloak as a shitspawn

### DIFF
--- a/Resources/Prototypes/SS220/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/SS220/Entities/Clothing/Neck/cloaks.yml
@@ -40,6 +40,7 @@
   parent: ClothingNeckBase
   id: ClothingCloak1984
   name: плащ 1984
+  suffix: Shitspawn
   description: Литерали 1984.
   components:
     - type: Sprite
@@ -51,6 +52,9 @@
           - scale: 0.125, 0.125
             sprite: SS220/Clothing/Neck/Cloaks/shitty-1984.rsi
             state: equipped-NECK
+    - type: Tag
+      tags:
+      - ClothMade
 
 - type: entity
   parent: ClothingNeckBase


### PR DESCRIPTION
## Описание PR
Поступила жалоба, что плащ 1984 не помечен как шитспавн и вообще может использоваться в хамелеоне, исправляюсь.

**Медиа**

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

no cl this time
