### PR TITLE
MeatWheatFix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -515,6 +515,12 @@
         reagents:
         - ReagentId: UncookedAnimalProteins
           Quantity: 1
+  #SS220-Keep-our-meatwheat begin
+  - type: Construction
+    graph: ClumpToMeat
+    node: start
+    defaultTarget: make meat
+  #SS220-Keep-our-meatwheat end
 
 - type: entity
   name: raw snake meat


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Вернул привязку рецепта к мясопщенице

fix #2060  

Остальное - изменения которые игроки приняли за баг, либо saggitarius-issue. 
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: AlwyAnri
- fix: Снова можно раскатать мясопшеницу в мясо!
