### PR TITLE
Atmos Threshold configued

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -58,7 +58,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         [DataField]
         public bool IsPressureLockoutManuallyDisabled = false;
         /// <summary>
-        /// The time when the manual pressure lockout will be reenabled.
+        /// The time when the manual pressure lockout will be reenabled. 
         /// </summary>
         [DataField]
         [AutoPausedField]

--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -35,7 +35,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         ///     In releasing mode, do not pump when environment pressure is below this limit.
         /// </summary>
         [DataField]
-        public float UnderPressureLockoutThreshold = 80; // this must be tuned in conjunction with atmos.mmos_spacing_speed
+        public float UnderPressureLockoutThreshold = 40; // SS220 Atmos Threshold configued // this must be tuned in conjunction with atmos.mmos_spacing_speed
 
         /// <summary>
         ///     Pressure locked vents still leak a little (leading to eventual pressurization of sealed sections)
@@ -58,7 +58,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         [DataField]
         public bool IsPressureLockoutManuallyDisabled = false;
         /// <summary>
-        /// The time when the manual pressure lockout will be reenabled. 
+        /// The time when the manual pressure lockout will be reenabled.
         /// </summary>
         [DataField]
         [AutoPausedField]


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Было проведено личностное наблюдение в разрезе отсутствия метрик. Экспериментально вношу балансную правку в порог блокировки вентиляций воздуха, в два раза снижая этот порог.

Перед этим я достаточно ознакомился с: 
https://github.com/space-wizards/space-station-14/pull/29504
https://github.com/space-wizards/space-station-14/pull/28370
https://github.com/space-wizards/space-station-14/pull/29493

И изучил причины введения всей системы, согласно: https://docs.spacestation14.com/en/space-station-14/departments/atmos/proposals/atmos-rework.html

Я считаю, что у Partmedia данный функционал всё ещё в экспериментальном виде и предлагаю снизить порог до момента пока либо:
1. не соберём метрики, позволяющее определить как часто атмосферные техники взаимодействуют с воздушными сигналками по станции
2. PartMedia и энтузиасты не отконфигурируют этот порог самостоятельно

Почему это нужно:
Проблематика текущего порога заключается не в том, что станция слишком быстро теряет воздух из-за больших пространств. В силу нашего маппинга, на картах у нас может преобладать количество конкретно простора. 

Процесс разгерметизации занимает действительно время, чтобы все моли воздуха ушли, однако они уходят равномерно и постепенно, если справедливо условие, что присутствует источник разгерметизации. Также и смешивание газов комнат, одна из которых содержит условие разегрметизации - лишь определяет соседнюю комнату источником, из-за чего не происходит резких смешиваний. Однако как только пожарные шлюзы перекрывают атмосферные участки (комнаты/коридоры) - комната, потерявшая N количество воздуха при смешивании с другой комнатой - производит это резко, просто уравнивая свойства газов двух комнат. Соответственно это происходит при условии, что источника разгерметизации нет.

Из этой проблематики, представим зал прибытия в котором образовалась дыра от метеорита. Прибывший игрок пройдет через рагерметизацию, спустит в соседней комнате воздух.  После начнёт идти далее по коридорам внутрь станции, попутно создавая резкие перепады давления в комнатах. В нашей ситуации, с порогом в **80** это давление из-за перепадов **очень быстро** снижается до порога - когда давление не восстанавливается самостоятельно. Учитывая наши большие комнаты, восстановить его становится ещё сложнее. В такой ситуации Атмосферный Техник становится нужен сразу во всех частях станции, ведь место разгерметизации в основном ни только в зале прибытия.

С порогом в 40, мы расстянем момент утечки блокировки за счёт не такой близкой дистанции между дефолтом и порогом (110 - 80 с разницой в 30 или 110-40 с разницой в 70). Убийство давлением по кукле (человеку) начинается, если порог ниже 50. То есть будет ещё расстояние в 10кПа, которые помогут атмос-техникам восстановить атмосферу, не доведя её до заблокированной и убийственной. 

Восстановить саму атмосферу будет гораздо проще, так как воздушные вентиляции не будут такими бесполезными, отключаясь по любому чиху. При этом геймдизайное побуждение атмос-техников конкретно **бегать по станции и восстанавливать атмосферу** останется. 

**Медиа**
Отсутствует.

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- tweak: изменён порог блокировки воздушных вентиляций с 80кПа до 40кПа!
