### PR TITLE
Fix ghost roles entering cryostorage

### DIFF
--- a/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
+++ b/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
@@ -29,8 +29,7 @@ using Robust.Shared.Player;
 using Content.Server.Forensics;
 using Robust.Shared.Utility;
 using System.Globalization;
-using Content.Server.Roles; // SS220 Cryostorage ghost role fix
-using Content.Shared.Roles.Jobs; // SS220 Cryostorage ghost role fix
+using Content.Shared.Roles; // SS220 Cryostorage ghost role fix
 using Robust.Shared.Prototypes; // SS220 Cryostorage ghost role fix
 
 namespace Content.Server.Bed.Cryostorage;
@@ -54,7 +53,6 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
     [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
-    [Dependency] private readonly RoleSystem _role = default!; // SS220 Cryostorage ghost role fix
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!; // SS220 Cryostorage ghost role fix
 
     /// <inheritdoc/>
@@ -241,6 +239,15 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
             if (_stationRecords.TryGetRecord<GeneralStationRecord>(key, out var entry, stationRecords))
                 jobName = entry.JobTitle;
 
+            // SS220 Cryostorage ghost role fix begin
+            if (!_stationRecords.TryGetRecord<GeneralStationRecord>(key, out var record, stationRecords)
+                || !_prototypeManager.TryIndex<JobPrototype>(record.JobPrototype, out var jobProto)
+                || !jobProto.JoinNotifyCrew)
+            {
+                return;
+            }
+            // SS220 Cryostorage ghost role fix end
+
             // _stationRecords.RemoveRecord(key, stationRecords);
 
             // start 220 cryo department record
@@ -252,16 +259,6 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
             }
             // end 220 cryo department record
         }
-
-        // SS220 Cryostorage ghost role fix begin
-        if (!_role.MindHasRole<JobRoleComponent>(ent.Owner, out var role)
-            || role.Value.Comp1.JobPrototype is not { } jobPrototype
-            || !_prototypeManager.TryIndex(jobPrototype, out var jobProto)
-            || !jobProto.JoinNotifyCrew)
-        {
-            return;
-        }
-        // SS220 Cryostorage ghost role fix end
 
         _chatSystem.DispatchStationAnnouncement(station.Value,
             Loc.GetString(

--- a/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
+++ b/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
@@ -29,6 +29,9 @@ using Robust.Shared.Player;
 using Content.Server.Forensics;
 using Robust.Shared.Utility;
 using System.Globalization;
+using Content.Server.Roles; // SS220 Cryostorage ghost role fix
+using Content.Shared.Roles.Jobs; // SS220 Cryostorage ghost role fix
+using Robust.Shared.Prototypes; // SS220 Cryostorage ghost role fix
 
 namespace Content.Server.Bed.Cryostorage;
 
@@ -51,6 +54,8 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
     [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
+    [Dependency] private readonly RoleSystem _role = default!; // SS220 Cryostorage ghost role fix
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!; // SS220 Cryostorage ghost role fix
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -247,6 +252,16 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
             }
             // end 220 cryo department record
         }
+
+        // SS220 Cryostorage ghost role fix begin
+        if (!_role.MindHasRole<JobRoleComponent>(ent.Owner, out var role)
+            || role.Value.Comp1.JobPrototype is not { } jobPrototype
+            || !_prototypeManager.TryIndex(jobPrototype, out var jobProto)
+            || !jobProto.JoinNotifyCrew)
+        {
+            return;
+        }
+        // SS220 Cryostorage ghost role fix end
 
         _chatSystem.DispatchStationAnnouncement(station.Value,
             Loc.GetString(

--- a/Content.Server/SS220/TeleportAFKtoCryoSystem/TeleportAFKtoCryoSystem.cs
+++ b/Content.Server/SS220/TeleportAFKtoCryoSystem/TeleportAFKtoCryoSystem.cs
@@ -1,4 +1,4 @@
-// © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
+﻿// © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
 
 using System.Linq;
 using Content.Server.Preferences.Managers;
@@ -22,8 +22,8 @@ using Robust.Shared.Audio.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.SS220.TeleportAFKtoCryoSystem;
 using Content.Shared.Administration.Logs;
-using Content.Server.Ghost; // SS220 Cryostorage ghost role fix begin
-using Content.Server.Mind; // SS220 Cryostorage ghost role fix begin
+using Content.Server.Ghost;
+using Content.Server.Mind;
 
 namespace Content.Server.SS220.TeleportAFKtoCryoSystem;
 
@@ -38,8 +38,8 @@ public sealed class TeleportAFKtoCryoSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
-    [Dependency] private readonly GhostSystem _ghostSystem = default!; // SS220 Cryostorage ghost role fix begin
-    [Dependency] private readonly MindSystem _mindSystem = default!; // SS220 Cryostorage ghost role fix begin
+    [Dependency] private readonly GhostSystem _ghostSystem = default!;
+    [Dependency] private readonly MindSystem _mindSystem = default!;
 
     private float _afkTeleportTocryo;
 

--- a/Content.Server/SS220/TeleportAFKtoCryoSystem/TeleportAFKtoCryoSystem.cs
+++ b/Content.Server/SS220/TeleportAFKtoCryoSystem/TeleportAFKtoCryoSystem.cs
@@ -145,7 +145,7 @@ public sealed class TeleportAFKtoCryoSystem : EntitySystem
         if (station != _station.GetOwningStation(cryopodUid))
             return false;
 
-        // SS220 Cryostorage ghost role fix begin
+        // Kicks the mind out of the entity if it cannot enter the cryostorage
         if (!HasComp<CanEnterCryostorageComponent>(target))
         {
             if (_mindSystem.GetMind(target) is { } mind)
@@ -154,7 +154,6 @@ public sealed class TeleportAFKtoCryoSystem : EntitySystem
             }
             return true;
         }
-        // SS220 Cryostorage ghost role fix end
 
         var portal = Spawn(teleportPortralID, Transform(target).Coordinates);
 

--- a/Content.Server/SS220/TeleportAFKtoCryoSystem/TeleportAFKtoCryoSystem.cs
+++ b/Content.Server/SS220/TeleportAFKtoCryoSystem/TeleportAFKtoCryoSystem.cs
@@ -1,4 +1,4 @@
-﻿// © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
+// © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
 
 using System.Linq;
 using Content.Server.Preferences.Managers;
@@ -22,6 +22,8 @@ using Robust.Shared.Audio.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.SS220.TeleportAFKtoCryoSystem;
 using Content.Shared.Administration.Logs;
+using Content.Server.Ghost; // SS220 Cryostorage ghost role fix begin
+using Content.Server.Mind; // SS220 Cryostorage ghost role fix begin
 
 namespace Content.Server.SS220.TeleportAFKtoCryoSystem;
 
@@ -36,6 +38,8 @@ public sealed class TeleportAFKtoCryoSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly GhostSystem _ghostSystem = default!; // SS220 Cryostorage ghost role fix begin
+    [Dependency] private readonly MindSystem _mindSystem = default!; // SS220 Cryostorage ghost role fix begin
 
     private float _afkTeleportTocryo;
 
@@ -140,6 +144,17 @@ public sealed class TeleportAFKtoCryoSystem : EntitySystem
     {
         if (station != _station.GetOwningStation(cryopodUid))
             return false;
+
+        // SS220 Cryostorage ghost role fix begin
+        if (!HasComp<CanEnterCryostorageComponent>(target))
+        {
+            if (_mindSystem.GetMind(target) is { } mind)
+            {
+                _ghostSystem.OnGhostAttempt(mind, false);
+            }
+            return true;
+        }
+        // SS220 Cryostorage ghost role fix end
 
         var portal = Spawn(teleportPortralID, Transform(target).Coordinates);
 

--- a/Resources/Locale/ru-RU/bed/cryostorage/cryogenic-storage.ftl
+++ b/Resources/Locale/ru-RU/bed/cryostorage/cryogenic-storage.ftl
@@ -2,7 +2,7 @@
 
 earlyleave-cryo-job-unknown = Должность неизвестна
 earlyleave-cryo-announcement =
-    { $character } ({ $job }) { $gender ->
+    { $character } ({ $job }) { $entity ->
         [male] был перемещён
         [female] была перемещена
         [epicene] были перемещены

--- a/Resources/Locale/ru-RU/bed/cryostorage/cryogenic-storage.ftl
+++ b/Resources/Locale/ru-RU/bed/cryostorage/cryogenic-storage.ftl
@@ -2,7 +2,7 @@
 
 earlyleave-cryo-job-unknown = Должность неизвестна
 earlyleave-cryo-announcement =
-    { $character } ({ $job }) { $entity ->
+    { $character } ({ $job }) { GENDER($entity) ->
         [male] был перемещён
         [female] была перемещена
         [epicene] были перемещены

--- a/Resources/Locale/ru-RU/bed/cryostorage/cryogenic-storage.ftl
+++ b/Resources/Locale/ru-RU/bed/cryostorage/cryogenic-storage.ftl
@@ -1,6 +1,7 @@
 ### Announcement
 
 earlyleave-cryo-job-unknown = Должность неизвестна
+# SS220 Cryostorage ghost role fix
 earlyleave-cryo-announcement =
     { $character } ({ $job }) { GENDER($entity) ->
         [male] был перемещён

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -107,6 +107,7 @@
   - type: ProtectedFromStepTriggers
   - type: NoSlip
   - type: Insulated
+  - type: DoAfter # SS220 Cryostorage ghost role fix
 
 - type: entity
   parent: MobSiliconBase


### PR DESCRIPTION
## Описание PR

- Добавлен `DoAfterComponent` для `MobSiliconBase`, потому что без него каргобот бросал кучу ошибок при попытке телепортации в крио,
- Исправлена локализация сообщения об отправке в крио (вариация по гендеру)
- Добавлен альтернативный кик из роли если кукла не приспособлена для крио (например, гост роли),
- Теперь об уходе в крио не будет объявления для тех кукол, которые не объявляются при прибытии

**Медиа**

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

no cl
