### PR TITLE
Cc id show fix

### DIFF
--- a/Resources/Locale/ru-RU/ss220/job/job-name.ftl
+++ b/Resources/Locale/ru-RU/ss220/job/job-name.ftl
@@ -2,11 +2,11 @@ job-name-magistrate = магистрат
 
 job-name-cc-default = ЦК
 job-name-cc-agent = агент ЦК
-job-name-cc-oficier = офицер ЦК
-job-name-cc-operational-oficier = полевой офицер ЦК
+job-name-cc-oficier = офицер Центрального Командования
+job-name-cc-operational-oficier = полевой Офицер Центрального Комадования
 
 job-name-cburn-agent = агент РХБЗ
-job-name-cc-srt-operative = оперативник ГСН
+job-name-cc-srt-operative = оперативник Группы Специального Назначения
 job-name-ert-commander = лидер отряда ОБР
 job-name-ert-chaplain = священник ОБР
 

--- a/Resources/Locale/ru-RU/ss220/job/job-name.ftl
+++ b/Resources/Locale/ru-RU/ss220/job/job-name.ftl
@@ -3,10 +3,10 @@ job-name-magistrate = магистрат
 job-name-cc-default = ЦК
 job-name-cc-agent = агент ЦК
 job-name-cc-oficier = офицер ЦК
-job-name-cc-operational-oficier = полевой Офицер ЦК
+job-name-cc-operational-oficier = полевой офицер ЦК
 
 job-name-cburn-agent = агент РХБЗ
-job-name-cc-srt-operative = оперативник Группы Специального Назначения
+job-name-cc-srt-operative = оперативник ГСН
 job-name-ert-commander = лидер отряда ОБР
 job-name-ert-chaplain = священник ОБР
 

--- a/Resources/Locale/ru-RU/ss220/job/job-name.ftl
+++ b/Resources/Locale/ru-RU/ss220/job/job-name.ftl
@@ -2,8 +2,8 @@ job-name-magistrate = магистрат
 
 job-name-cc-default = ЦК
 job-name-cc-agent = агент ЦК
-job-name-cc-oficier = офицер Центрального Командования
-job-name-cc-operational-oficier = полевой Офицер Центрального Комадования
+job-name-cc-oficier = офицер ЦК
+job-name-cc-operational-oficier = полевой Офицер ЦК
 
 job-name-cburn-agent = агент РХБЗ
 job-name-cc-srt-operative = оперативник Группы Специального Назначения

--- a/Resources/Prototypes/SS220/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Misc/identification_cards.yml
@@ -36,14 +36,14 @@
     layers:
     - state: silver
     - state: idcentcom
-    - type: IdCard
-      jobTitle: job-name-nt-politician #SS220 (upstream 65 localization)
-    - type: Access
-      groups:
-      - AllAccess # SS220 Fast fix access
-      - CentralCommand
-    - type: PresetIdCard
-      job: CentCommNanoTrasenDiplomat
+  - type: IdCard
+    jobTitle: job-name-nt-politician #SS220 (upstream 65 localization)
+  - type: Access
+    groups:
+    - AllAccess # SS220 Fast fix access
+    - CentralCommand
+  - type: PresetIdCard
+    job: CentCommNanoTrasenDiplomat
 
 - type: entity
   parent: CentcomIDCard

--- a/Resources/Prototypes/SS220/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Misc/identification_cards.yml
@@ -42,6 +42,8 @@
       groups:
       - AllAccess # SS220 Fast fix access
       - CentralCommand
+    - type: PresetIdCard
+      job: CentCommNanoTrasenDiplomat
 
 - type: entity
   parent: CentcomIDCard
@@ -55,6 +57,8 @@
       groups:
       - AllAccess # SS220 Fast fix access
       - CentralCommand
+    - type: PresetIdCard
+      job: CentcomFieldOfficer
 
 - type: entity
   parent: CentcomIDCard
@@ -68,6 +72,8 @@
       groups:
       - AllAccess # SS220 Fast fix access
       - CentralCommand
+    - type: PresetIdCard
+      job: CentcommOfficer
 
 - type: entity
   parent: CentcomIDCard
@@ -83,6 +89,8 @@
       tags:
       - CentralCommandGSN
       - CentralCommand
+    - type: PresetIdCard
+      job: CentcomOperativeSRT
 
 - type: entity # SS220 - Security dog Roxi ID card
   parent: IDCardStandard
@@ -123,6 +131,8 @@
       groups:
       - AllAccess # SS220 Fast fix access
       - CentralCommand
+    - type: PresetIdCard
+      job: CentComNanoTrasenAdmiral
 
 - type: entity
   parent: IDCardStandard

--- a/Resources/Prototypes/SS220/Roles/Jobs/CentComm/CentcomFieldOfficier.yml
+++ b/Resources/Prototypes/SS220/Roles/Jobs/CentComm/CentcomFieldOfficier.yml
@@ -34,7 +34,7 @@
 
 - type: job
   id: CentcomFieldOfficer
-  name: job-name-centcomoff
+  name: job-name-cc-operational-oficier
   description: job-description-centcomoff
   setPreference: false
   startingGear: CentcomFieldOfficerGear

--- a/Resources/Prototypes/SS220/Roles/Jobs/CentComm/CentcomOfficer.yml
+++ b/Resources/Prototypes/SS220/Roles/Jobs/CentComm/CentcomOfficer.yml
@@ -34,7 +34,7 @@
 
 - type: job
   id: CentcommOfficer
-  name: job-name-centcomoff
+  name: job-name-cc-oficier
   description: job-description-centcomoff
   setPreference: false
   startingGear: CentCommOfficerGear

--- a/Resources/Prototypes/SS220/Roles/Jobs/CentComm/CentcomOperativeSRT.yml
+++ b/Resources/Prototypes/SS220/Roles/Jobs/CentComm/CentcomOperativeSRT.yml
@@ -34,7 +34,7 @@
 
 - type: job
   id: CentcomOperativeSRT
-  name: job-name-centcomoff
+  name: job-name-cc-srt-operative
   description: job-description-centcomoff
   setPreference: false
   startingGear: CentcomOperativeSRTGear

--- a/Resources/Prototypes/SS220/Roles/Jobs/CentComm/NanoTrasenAdmiral.yml
+++ b/Resources/Prototypes/SS220/Roles/Jobs/CentComm/NanoTrasenAdmiral.yml
@@ -34,7 +34,7 @@
 
 - type: job
   id: CentComNanoTrasenAdmiral
-  name: job-name-centcomoff
+  name: job-name-nt-admiral
   description: job-description-centcomoff
   setPreference: false
   startingGear: CentComNanoTrasenAdmiralGear

--- a/Resources/Prototypes/SS220/Roles/Jobs/CentComm/NanoTrasenDiplomat.yml
+++ b/Resources/Prototypes/SS220/Roles/Jobs/CentComm/NanoTrasenDiplomat.yml
@@ -34,7 +34,7 @@
 
 - type: job
   id: CentCommNanoTrasenDiplomat
-  name: job-name-centcomoff
+  name: job-name-nt-politician
   description: job-description-centcomoff
   setPreference: false
   startingGear: CentCommNanoTrasenDiplomatGear


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Исправляет баг, суть которого заключается в том, что Офицеры ЦК, адмирал НТ, дипломат НТ и оперативник ГСН в ID карте отображались как "Представитель ЦК"

- [x] ~~Где-то видимо что-то не так сделал, и дипломат не починился. Завтра буду чинить~~ Табуляцию не правильно сделали

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
