### PR TITLE
FIX: Nuke unanchor w/o disk

### DIFF
--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -167,6 +167,7 @@ public sealed class NukeSystem : EntitySystem
         if (component.Status == NukeStatus.ARMED)
             return;
 
+        /* ss220 nuke anchor fix start (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/2194)
         // Nuke has to have the disk in it to be moved
         if (!component.DiskSlot.HasItem)
         {
@@ -174,6 +175,7 @@ public sealed class NukeSystem : EntitySystem
             _popups.PopupEntity(msg, uid, args.Actor, PopupType.MediumCaution);
             return;
         }
+           ss220 nuke anchor fix end */
 
         // manually set transform anchor (bypassing anchorable)
         // todo: it will break pullable system


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Ядерку теперь можно открепить без диска ядерной аутентификации (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/2194)

**Медиа**

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- fix: Ядерную бомбу теперь снова можно открепить без диска ядерной аутентификации
