### PR TITLE
Species Height Patch

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -36,7 +36,7 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.4
+          radius: 0.375
         density: 185
         restitution: 0.0
         mask:
@@ -91,7 +91,7 @@
 #   SS220-change-races-height begin
     noRot: true
     drawdepth: Mobs
-    scale: 1.16, 1.16
+    scale: 1.1, 1.1
 #   SS220-change-races-height end
     layers:
       - map: [ "enum.HumanoidVisualLayers.Chest" ]
@@ -149,7 +149,7 @@
   components:
 # SS220-change-races-height begin
   - type: Sprite
-    scale: 1.16, 1.16
+    scale: 1.1, 1.1
 # SS220-change-races-height end
   - type: HumanoidAppearance
     species: Arachnid

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -18,7 +18,7 @@
   - type: Sprite
     noRot: true
     drawdepth: Mobs
-    scale: 0.8, 0.8
+    scale: 0.9, 0.9
 # SS220-change-races-height end
   - type: Body
     prototype: Diona
@@ -94,7 +94,7 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.35
+          radius: 0.325
         density: 300 #weighs more than humans because wood
         restitution: 0.0
         mask:
@@ -138,7 +138,7 @@
   components:
 # SS220-change-races-height begin
   - type: Sprite
-    scale: 0.8, 0.8
+    scale: 0.9, 0.9
 # SS220-change-races-height end
   - type: HumanoidAppearance
     species: Diona

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -46,7 +46,7 @@
           !type:PhysShapeCircle
           radius: 0.35
         # they r smaller
-        density: 185 #SS220-change-races-height
+        density: 120
         restitution: 0.0
         mask:
         - MobMask

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -38,7 +38,7 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.35
+          radius: 0.325
         density: 185
         restitution: 0.0
         mask:
@@ -98,7 +98,7 @@
   - type: Sprite # sprite again because we want different layer ordering
     noRot: true
     drawdepth: Mobs
-    scale: 0.8, 0.8 #SS220-change-races-height
+    scale: 0.9, 0.9 #SS220-change-races-height
     layers:
       - map: [ "enum.HumanoidVisualLayers.Chest" ]
       - map: [ "enum.HumanoidVisualLayers.Head" ]
@@ -159,7 +159,7 @@
   components:
 # SS220-change-races-height begin
   - type: Sprite
-    scale: 0.8, 0.8
+    scale: 0.9, 0.9
 # SS220-change-races-height end
   - type: HumanoidAppearance
     species: Moth

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -22,7 +22,7 @@
   - type: Sprite
     noRot: true
     drawdepth: Mobs
-    scale: 1.13, 1.13
+    scale: 1.1, 1.1
 # SS220-change-races-height end
   - type: Body
     prototype: Reptilian
@@ -38,7 +38,7 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.40
+          radius: 0.375
         density: 185
         restitution: 0.0
         mask:
@@ -109,7 +109,7 @@
   components:
 # SS220-change-races-height begin
   - type: Sprite
-    scale: 1.13, 1.13
+    scale: 1.1, 1.1
 # SS220-change-races-height end
   - type: HumanoidAppearance
     species: Reptilian

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -13,7 +13,7 @@
   - type: Sprite
     noRot: true
     drawdepth: Mobs
-    scale: 0.8, 0.8
+    scale: 0.9, 0.9
 # SS220-change-races-height end
   - type: Body
     prototype: Slime
@@ -124,7 +124,7 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.35
+          radius: 0.325
         density: 185
         restitution: 0.0
         mask:
@@ -159,7 +159,7 @@
   components:
 # SS220-change-races-height begin
   - type: Sprite
-    scale: 0.8, 0.8
+    scale: 0.9, 0.9
 # SS220-change-races-height end
   - type: HumanoidAppearance
     species: SlimePerson

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -36,7 +36,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.30
-        density: 160
+        density: 185
         restitution: 0.0
         mask:
         - MobMask
@@ -68,8 +68,8 @@
 #   SS220-change-races-height begin
     noRot: true
     drawdepth: Mobs
-    scale: 0.7, 0.7
-#   SS220-change-races-height end 
+    scale: 0.85, 0.85
+#   SS220-change-races-height end
     layers:
     - map: [ "enum.HumanoidVisualLayers.Chest" ]
     - map: [ "enum.HumanoidVisualLayers.Head" ]
@@ -175,7 +175,7 @@
   components:
 # SS220-change-races-height begin
   - type: Sprite
-    scale: 0.7, 0.7
+    scale: 0.85, 0.85
 # SS220-change-races-height end
   - type: HumanoidAppearance
     species: Vox

--- a/Resources/Prototypes/SS220/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/SS220/Entities/Mobs/Species/felinid.yml
@@ -9,7 +9,7 @@
     netsync: false
     noRot: true
     drawdepth: Mobs
-    scale: 0.7, 0.7
+    scale: 0.85, 0.85
     layers:
       - map: [ "enum.HumanoidVisualLayers.Chest" ]
       - map: [ "enum.HumanoidVisualLayers.Head" ]
@@ -67,7 +67,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.30
-        density: 160
+        density: 185
         restitution: 0.0
         mask:
         - MobMask
@@ -124,7 +124,7 @@
     netsync: false
     noRot: true
     drawdepth: Mobs
-    scale: 0.7, 0.7
+    scale: 0.85, 0.85
     layers:
       # TODO BODY Turn these into individual body parts?
         - map: [ "enum.HumanoidVisualLayers.Chest" ]

--- a/Resources/Prototypes/SS220/Entities/Mobs/Species/tajaran.yml
+++ b/Resources/Prototypes/SS220/Entities/Mobs/Species/tajaran.yml
@@ -29,7 +29,7 @@
   - type: Sprite
     noRot: true
     drawdepth: Mobs
-    scale: 0.9, 0.9
+    scale: 0.95, 0.95
   - type: Body
     prototype: Tajaran
     requiredLegs: 2
@@ -115,7 +115,7 @@
   description: A dummy Tajaran meant to be used in character setup.
   components:
   - type: Sprite
-    scale: 0.9, 0.9
+    scale: 0.95, 0.95
   - type: HumanoidAppearance
     species: Tajaran
   - type: Inventory

--- a/Resources/Prototypes/SS220/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/SS220/Entities/Mobs/Species/vulpkanin.yml
@@ -15,7 +15,7 @@
   - type: Sprite
     noRot: true
     drawdepth: Mobs
-    scale: 0.9, 0.9
+    scale: 0.95, 0.95
   - type: Body
     prototype: Vulpkanin
     requiredLegs: 2
@@ -81,7 +81,7 @@
   description: A dummy vulpkanin meant to be used in character setup.
   components:
     - type: Sprite
-      scale: 0.9, 0.9
+      scale: 0.95, 0.95
     - type: HumanoidAppearance
       species: Vulpkanin
 


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Этот патч подразумевает следующие изменения:
Для начала, вводятся негласные границы для роста. Возможно они будут в будущем отражены в каком-нибудь ДД, которого нигде нет, но это уже оговорено с Адучем и принято. Уж простите мне мою занятость и невозможность сразу подготовить ДД.

Ограничение для роста расс по скейлу от дефолта (дефолт - хуман, он же base species):
Максимально в высоту: `1,15x`
Минимально в высоту: `0,8x`

Теперь скейлы между расами будут изменяться на, всегда кратные, 5 сотых единиц (0,05х).
Теперь между расами разница сокращена вдвое, приводя их в более игрово-условный вид, чем ранее.

Из:
```
Унатх     - 1,15
Человек   - 1
Таяран    - 0,9
Ниан      - 0,8
Вокс      - 0,7
```
В:
```
Кто-то    - 1,15
Унатх     - 1,1
Кто-то    - 1,05
Человек   - 1
Таяран    - 0,95
Ниан      - 0,9
Вокс      - 0,85
Дворфы    - 0,8
```

В новом распределение роста можно заметить относительно нелорную особенность: дворфы ниже воксов по скейлу. С точки зрения механики - это абсолютная правда, однако. Стоит учесть, что дворфы - единственная раса, чей рост меняется не изменением по обеим осям (X и Y), а лишь изменением по оси Y. Поэтому из-за их эффекта приплющенности из-за сжатия по Y - дворфы в любом случае будут создавать эффект более низкого персонажа, нежели другие. 

Примечание: однако если разница всё же будет сильно заметна между дворфами и более низкими персонажами, возможно дворфам будет малость увеличен рост в связи с нашими правками.

Помимо роста, также были изменены и хитбоксы некоторых переходящих рас. Теперь унатхи и Арахниды не будут испытывать проблем с прохождением в места с перилами. Более того, теперь эти расы и их позиция стандартного роста - максимальный рост без осложнений. Будущие расы с ростом максимального порога (1,15) - будут иметь хитбокс, вызывающий осложнения в передвижении. 

После этого патча, будет создана задача на основе обсуждений ДД роста с Адучем, которая будет нацелена на создание персонализации роста для рас. 

**Медиа**
![image](https://github.com/user-attachments/assets/e6160e99-934b-463c-bc6a-d3bef4fcb6d4)
![image](https://github.com/user-attachments/assets/44bcf3a7-d2be-46cb-9b2f-8141d98d0b4d)
![image](https://github.com/user-attachments/assets/404eaf0e-43e7-4d62-b572-2317570c05ed)
![image](https://github.com/user-attachments/assets/6f8a2183-b771-44d0-8cf9-2ae4bc6f3b63)


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- tweak: подправлен рост рас в более игрово-условный формат!
