### PR TITLE
Dice sounds tweak

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/dice.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/dice.yml
@@ -4,6 +4,7 @@
   id: BaseDice
   components:
   - type: Dice
+# SS220 dice sound tweak
     sound:
       collection: Dice
       params:
@@ -19,6 +20,7 @@
       path: /Audio/Effects/drop.ogg
       params:
         volume: -100
+# SS220 dice sound tweak end
   - type: UseDelay
   - type: Sprite
     sprite: Objects/Fun/dice.rsi

--- a/Resources/Prototypes/Entities/Objects/Fun/dice.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/dice.yml
@@ -7,7 +7,18 @@
     sound:
       collection: Dice
       params:
-          variation: 0.050
+        variation: 0.050
+        volume: 2
+  - type: EmitSoundOnCollide
+    sound:
+      collection: Dice
+      params:
+        variation: 0.050
+  - type: EmitSoundOnLand
+    sound:
+      path: /Audio/Effects/drop.ogg
+      params:
+        volume: -100
   - type: UseDelay
   - type: Sprite
     sprite: Objects/Fun/dice.rsi

--- a/Resources/Prototypes/Entities/Objects/Fun/dice.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/dice.yml
@@ -4,6 +4,10 @@
   id: BaseDice
   components:
   - type: Dice
+    sound:
+      collection: Dice
+      params:
+          variation: 0.050
   - type: UseDelay
   - type: Sprite
     sprite: Objects/Fun/dice.rsi


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Добавление вариации питча звуков падения кубиков, плюс удаление звука падения baseitem (убого звучит, когда одно на другое)

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- tweak: Добавлена вариативность питча звука падения игральных кубов

