### PR TITLE
FIX: Dark Reaper in context menu until material

### DIFF
--- a/Content.Shared/SS220/DarkReaper/DarkReaperSharedSystem.cs
+++ b/Content.Shared/SS220/DarkReaper/DarkReaperSharedSystem.cs
@@ -397,6 +397,7 @@ public abstract class SharedDarkReaperSystem : EntitySystem
         {
             EnsureComp<PullerComponent>(uid).NeedsHands = false;
             _tag.AddTag(uid, "DoorBumpOpener");
+            _tag.RemoveTag(uid, "HideContextMenu");
 
             if (TryComp<ExplosionResistanceComponent>(uid, out var explosionResistanceComponent))
             {
@@ -412,6 +413,7 @@ public abstract class SharedDarkReaperSystem : EntitySystem
         else
         {
             _tag.RemoveTag(uid, "DoorBumpOpener");
+            _tag.AddTag(uid, "HideContextMenu");
             comp.StunScreamStart = null;
             comp.MaterializedStart = null;
 

--- a/Resources/Prototypes/SS220/DemonRofler/mob.yml
+++ b/Resources/Prototypes/SS220/DemonRofler/mob.yml
@@ -19,6 +19,7 @@
   - type: Tag
     tags:
     - DoorBumpOpener
+    - HideContextMenu
   - type: StatusEffects
     allowed: []
   - type: ContainerContainer


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Тёмный жнец теперь не отображается через ПКМ, пока он в астрале (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1666)

**Медиа**

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

no cl
