### PR TITLE
Fix deadlock for exclusive open doors (which are usually placed when you walk out in space)

### DIFF
--- a/Content.Server/DeviceLinking/Systems/DoorSignalControlSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/DoorSignalControlSystem.cs
@@ -99,6 +99,8 @@ namespace Content.Server.DeviceLinking.Systems
                 _signalSystem.SendSignal(uid, door.OutOpen, false);
             }
             else if (args.State == DoorState.Open
+                     || args.State == DoorState.Opening
+                     || args.State == DoorState.Closing
                      || args.State == DoorState.Emagging)
             {
                 // say the door is open whenever it would be letting air pass


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Убирает дедлок в который попадают шлюзы, которые сконфигурированы, чтобы лишь один из них был открыт.
Фиксит блокирующиеся двери шлюзов для выхода в космос.

Изменения скопированы из основного репозитория space-wizards/space-station-14, поэтому дополнительные пометки не добавлял.

Раньше обе двери могли открыться и заблокироваться в открытом положении из-за чего происходила разгерметизация станции.

**Медиа**
https://github.com/user-attachments/assets/83b903a2-3873-4d39-b8dc-8753acf39671

Вот демонстрация как это работает без изменений. Происходит дедлок дверей в открытом положении:
https://github.com/user-attachments/assets/8476f7c2-14b6-4dde-a0cc-29103759779c



**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl: CrafterKolyan
- fix: Пофикшены блокирующиеся двери шлюзов для выхода в космос, которые могли остаться в заблокированном открытом положении, нарушая герметизацию станции.