### PR TITLE
HOTFIX-drozd-auto-gunmode-remove

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -153,8 +153,8 @@
       selectedMode: Burst
       soundGunshot:
         path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
-#      availableModes: #ss220 gunmodes
-#        - Burst       #ss220 gunmodes
+      availableModes:
+        - Burst
       shotsPerBurst: 3
       burstCooldown: 0.25
     - type: ItemSlots


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR

Исправлено наличие автоогня у дрозда. На апстрим с обновлением https://github.com/space-wizards/space-station-14/pull/31292 (в котором дрозд был изменен на оружие с возможностью лишь огня очередями) наложился наш старый ПР https://github.com/SerbiaStrong-220/space-station-14/pull/1601 из-за чего дрозд получил возможность автоогня со скорострельностью 12.0

**Медиа**

Видео до фикса:

https://github.com/user-attachments/assets/1ce91028-90ee-48f8-a828-c2b4c06e8e06

После:
![изображение](https://github.com/user-attachments/assets/a68fe183-41a9-4148-8c61-67b2b8a70f2a)
![изображение](https://github.com/user-attachments/assets/eab1d532-65ab-4939-ba1c-e73cddbeb861)

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**


no cl
