### PR TITLE
Ruins & VGroid distance

### DIFF
--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -65,6 +65,8 @@
           minCount: 2
           maxCount: 3 # SS2200 Counter Ruins Update
           stationGrid: false
+          minimumDistance: 400 # SS220 Ruins distance
+          maximumDistance: 650 # SS220 Ruins distance
           paths:
           # - /Maps/Ruins/chunked_tcomms.yml # SS220 Removed with Ruins Update (balance Tweak)
           - /Maps/Ruins/biodome_satellite.yml
@@ -83,8 +85,8 @@
           - /Maps/SS220/Ruins/WarshuttleWreck_SS220.yml
           # SS220 Ruins Update Map End
         vgroid: !type:DungeonSpawnGroup
-          minimumDistance: 300
-          maximumDistance: 350
+          minimumDistance: 900 # SS220 VGroid distance
+          maximumDistance: 1350 # SS220 VGroid distance
           nameDataset: names_borer
           stationGrid: false
           addComponents:


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Небольшое изменение дистанций спавна гридов. У руин это дуга между радиусами 400 - 650. У Планетоида это 900 - 1350.

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- tweak: Изменены дистанции спавна космических руин и планетоида.
