### PR TITLE
Zombies can see Initial Infected

### DIFF
--- a/Resources/Prototypes/StatusIcon/faction.yml
+++ b/Resources/Prototypes/StatusIcon/faction.yml
@@ -17,6 +17,7 @@
     components:
     - ShowAntagIcons
     - InitialInfected
+    - Zombie
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: InitialInfected


### PR DESCRIPTION
## Описание PR
Теперь зомби видят нулевых пациентов.

Я не раз видел ситуации когда один нулевой пациент готовит диверсию, а второй через 5 минут смены уже начинает кусать всех, заставляя первого "воевать на два фронта". Мне это сильно не нравится и я видел в дискорде поддержку этой идеи.

Это спорное изменение с точки зрения лора, но можно объяснить обе позиции:
С одной стороны, зомби полностью отбитые и просто преследуют живых.
С другой стороны, нулевые пациенты - биотеррористы Синдиката, в которых с начала смены в какой-то форме находится\живёт зомби вирус, который превратившиеся могут учуять.

**Медиа**
![{07EDA331-58D1-404D-A837-15F757F743E2}](https://github.com/user-attachments/assets/ac33f8e4-a4ce-49f7-9b9a-0dcfa88a5b3f)


**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- add: Теперь зомби видят нулевых пациентов
