### PR TITLE
FIX: Thief beacon double steal target

### DIFF
--- a/Content.Server/Objectives/Systems/StealConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/StealConditionSystem.cs
@@ -29,6 +29,7 @@ public sealed class StealConditionSystem : EntitySystem
     private EntityQuery<ContainerManagerComponent> _containerQuery;
 
     private HashSet<Entity<TransformComponent>> _nearestEnts = new();
+    private HashSet<EntityUid> _countedItems = new(); //ss220 beacon double steal target fix
 
     public override void Initialize()
     {
@@ -104,6 +105,8 @@ public sealed class StealConditionSystem : EntitySystem
         var containerStack = new Stack<ContainerManagerComponent>();
         var count = 0;
 
+        _countedItems.Clear(); //ss220 beacon double steal target fix
+
         //check stealAreas
         if (condition.CheckStealAreas)
         {
@@ -174,6 +177,11 @@ public sealed class StealConditionSystem : EntitySystem
 
     private int CheckStealTarget(EntityUid entity, StealConditionComponent condition)
     {
+        //ss220 beacon double steal target fix start
+        if (_countedItems.Contains(entity))
+            return 0;
+        //ss220 beacon double steal target fix end
+
         // check if this is the target
         if (!TryComp<StealTargetComponent>(entity, out var target))
             return 0;
@@ -195,6 +203,8 @@ public sealed class StealConditionSystem : EntitySystem
                     return 0;
             }
         }
+
+        _countedItems.Add(entity); //ss220 beacon double steal target fix
 
         return TryComp<StackComponent>(entity, out var stack) ? stack.Count : 1;
     }


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Воровской маяк теперь не удваивает сворованную цель. (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/2254)

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

no cl
