### PR TITLE
FIX: Random crystal shard

### DIFF
--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/objects/materials/crystal_shard.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/objects/materials/crystal_shard.ftl
@@ -1,5 +1,9 @@
 ent-ShardCrystalBase = осколок кристалла
     .desc = Небольшой кусочек кристалла.
+#ss220 white crystal loc start
+ent-ShardCrystalWhite = белый осколок кристалла
+    .desc = { ent-ShardCrystalBase.desc }
+#ss220 white crystal loc end
 ent-ShardCrystalCyan = голубой осколок кристалла
     .desc = Небольшой кусочек кристалла.
 ent-ShardCrystalBlue = синий осколок кристалла

--- a/Resources/Prototypes/Entities/Objects/Materials/crystal_shard.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/crystal_shard.yml
@@ -197,4 +197,5 @@
       - ShardCrystalBlue
       - ShardCrystalCyan
       - ShardCrystalRed
+      - ShardCrystalWhite #ss220 random white crystal fix
     chance: 1


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Теперь в рандомном спавне осколков кристалла может выпасть и белый осколок.
(fix: https://discord.com/channels/1097181193939730453/1312389772878024847)

**Медиа**

![image](https://github.com/user-attachments/assets/55f1998f-468d-4aa8-9a8f-ad399b530ad3)


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

no cl
