### PR TITLE
FIX: Diagonal structures created with south orientation

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/grille_diagonal.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/grille_diagonal.yml
@@ -7,16 +7,16 @@
         - to: grilleDiagonal
           completed:
             - !type:SnapToGrid
-              southRotation: false
+              southRotation: false #ss220 rotation fix
           steps:
             - material: MetalRod
               amount: 2
               doAfter: 1
-              
+
         - to: clockworkGrilleDiagonal
           completed:
             - !type:SnapToGrid
-              southRotation: false
+              southRotation: false #ss220 rotation fix
           steps:
             - material: MetalRod
               amount: 2
@@ -36,7 +36,7 @@
           steps:
             - tool: Cutting
               doAfter: 0.25
-              
+
     - node: clockworkGrilleDiagonal
       entity: ClockworkGrilleDiagonal
       edges:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/grille_diagonal.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/grille_diagonal.yml
@@ -7,7 +7,7 @@
         - to: grilleDiagonal
           completed:
             - !type:SnapToGrid
-              southRotation: true
+              southRotation: false
           steps:
             - material: MetalRod
               amount: 2
@@ -16,7 +16,7 @@
         - to: clockworkGrilleDiagonal
           completed:
             - !type:SnapToGrid
-              southRotation: true
+              southRotation: false
           steps:
             - material: MetalRod
               amount: 2

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/grille_diagonal.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/grille_diagonal.yml
@@ -12,7 +12,7 @@
             - material: MetalRod
               amount: 2
               doAfter: 1
-
+              
         - to: clockworkGrilleDiagonal
           completed:
             - !type:SnapToGrid
@@ -36,7 +36,7 @@
           steps:
             - tool: Cutting
               doAfter: 0.25
-
+              
     - node: clockworkGrilleDiagonal
       entity: ClockworkGrilleDiagonal
       edges:


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Диагональные строения теперь не впадают в ориентацию южной комы. Шкафы и еще многие предметы можно также пофиксить, но смысла особо не вижу, ибо на южной ориентации, они выглядят для всех нормально.

(fix: https://github.com/SerbiaStrong-220/space-station-14/issues/2241)

**Медиа**


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

no cl
