### PR TITLE
FIX: Mech action only to one entity

### DIFF
--- a/Content.Server/SS220/MechClothing/MechClothingSystem.cs
+++ b/Content.Server/SS220/MechClothing/MechClothingSystem.cs
@@ -34,11 +34,20 @@ public sealed class MechClothingSystem : EntitySystem
         SubscribeLocalEvent<MechClothingComponent, MechClothingGrabEvent>(OnInteract);
         SubscribeLocalEvent<MechClothingComponent, ComponentStartup>(OnStartUp);
         SubscribeLocalEvent<MechClothingComponent, GrabberDoAfterEvent>(OnMechGrab);
+        SubscribeLocalEvent<MechClothingComponent, ComponentShutdown>(OnShutdown);
     }
 
     private void OnStartUp(Entity<MechClothingComponent> ent, ref ComponentStartup args)
     {
-        ent.Comp.ItemContainer = _container.EnsureContainer<Container>(ent.Owner, "item-container");
+        ent.Comp.ItemContainer = _container.EnsureContainer<Container>(ent.Owner, ent.Comp.ContainerName);
+    }
+
+    private void OnShutdown(Entity<MechClothingComponent> ent, ref ComponentShutdown args)
+    {
+        if (!_container.TryGetContainer(ent.Owner, ent.Comp.ContainerName, out var container))
+            return;
+
+        _container.ShutdownContainer(container);
     }
 
     private void OnInteract(Entity<MechClothingComponent> ent, ref MechClothingGrabEvent args)

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -61,6 +61,7 @@ public abstract class SharedMechSystem : EntitySystem
         SubscribeLocalEvent<MechPilotComponent, CanAttackFromContainerEvent>(OnCanAttackFromContainer);
         SubscribeLocalEvent<MechPilotComponent, AttackAttemptEvent>(OnAttackAttempt);
     }
+
     //SS220-AddMechToClothing-start
     /// <summary>
     /// Responsible for logic if mech is clothing
@@ -75,20 +76,24 @@ public abstract class SharedMechSystem : EntitySystem
         _actions.AddAction(args.Wearer, ref ent.Comp.MechClothingUiActionEntity, ent.Comp.MechClothingUiAction, ent.Owner);
         _actions.AddAction(args.Wearer, ref ent.Comp.MechClothingGrabActionEntity, ent.Comp.MechClothingGrabAction);
     }
+
     /// <summary>
     /// Responsible for logic if mech is clothing
     /// </summary>
     private void OnUnequip(Entity<MechComponent> ent, ref ClothingGotUnequippedEvent args)
     {
-        if (_net.IsClient)
-            return;
-
         RemComp<MechClothingComponent>(args.Wearer);
 
         _actions.RemoveProvidedActions(args.Wearer, ent.Owner);
+
+        if (ent.Comp.MechClothingGrabActionEntity == null)
+            return;
+
         _actions.RemoveAction(args.Wearer, ent.Comp.MechClothingGrabActionEntity);
+        ent.Comp.MechClothingGrabActionEntity = null;
     }
     //SS220-AddMechToClothing-end
+
     private void OnToggleEquipmentAction(EntityUid uid, MechComponent component, MechToggleEquipmentEvent args)
     {
         if (args.Handled)
@@ -129,7 +134,7 @@ public abstract class SharedMechSystem : EntitySystem
         component.EquipmentContainer = _container.EnsureContainer<Container>(uid, component.EquipmentContainerId);
         component.BatterySlot = _container.EnsureContainer<ContainerSlot>(uid, component.BatterySlotId);
 
-        if (TryComp<MechRobotComponent>(uid, out var _))
+        if (HasComp<MechRobotComponent>(uid))
             component.PilotSlot = _container.EnsureContainer<ContainerSlot>(uid, component.PilotSlotId);
 
         UpdateAppearance(uid, component);
@@ -366,7 +371,7 @@ public abstract class SharedMechSystem : EntitySystem
     //SS220-AddMechToClothing-start
     public bool IsEmpty(MechComponent component, EntityUid uid)
     {
-        if (TryComp<MechRobotComponent>(uid, out var _))
+        if (HasComp<MechRobotComponent>(uid))
             return component.PilotSlot.ContainedEntity == null;
 
         return true;
@@ -498,7 +503,7 @@ public abstract class SharedMechSystem : EntitySystem
         args.Handled = true;
 
         //SS220-AddMechToClothing-start
-        if (!TryComp<MechRobotComponent>(uid, out var _))
+        if (!HasComp<MechRobotComponent>(uid))
             return;
         //SS220-AddMechToClothing-end
 

--- a/Content.Shared/SS220/MechClothing/MechClothingComponent.cs
+++ b/Content.Shared/SS220/MechClothing/MechClothingComponent.cs
@@ -14,19 +14,19 @@ public sealed partial class MechClothingComponent : Component
     /// <summary>
     /// The change in energy after each grab.
     /// </summary>
-    [DataField("grabEnergyDelta")]
+    [DataField]
     public float GrabEnergyDelta = -30;
 
     /// <summary>
     /// How long does it take to grab something?
     /// </summary>
-    [DataField("grabDelay")]
+    [DataField]
     public float GrabDelay = 2.5f;
 
     /// <summary>
     /// The sound played when a mech is grabbing something
     /// </summary>
-    [DataField("grabSound")]
+    [DataField]
     public SoundSpecifier GrabSound = new SoundPathSpecifier("/Audio/Mecha/sound_mecha_hydraulic.ogg");
 
     public EntityUid? AudioStream;
@@ -43,4 +43,6 @@ public sealed partial class MechClothingComponent : Component
     [ViewVariables, AutoNetworkedField]
     public EntityUid? CurrentEquipmentUid;
 
+    [DataField]
+    public string ContainerName = "item-container";
 }


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Action появлялся только у одной ентити, а для других кто наденет экзач, экшена не будет. Так же подчистил чутка код.
(fix: https://github.com/SerbiaStrong-220/space-station-14/issues/2328)

**Медиа**

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

no cl
