### PR TITLE
Thermals Into Arsenal Discipline

### DIFF
--- a/Resources/Prototypes/SS220/Research/experimental.yml
+++ b/Resources/Prototypes/SS220/Research/experimental.yml
@@ -4,7 +4,7 @@
   icon:
     sprite: Clothing/Eyes/Glasses/thermal.rsi
     state: icon
-  discipline: Experimental
+  discipline: Arsenal
   tier: 3
   cost: 10000
   recipeUnlocks:


### PR DESCRIPTION
С каждым днём мы всё дальше от бога.
🦋 🎷

Перевод термалов из ветки РнД в ветку СБ из-за больше специализации как на технологии для СБ. В рамках геймфлоу учёных, ветка РнД находится одной из первых, что изучается до конца, а именно до Т3, что даёт слишком быстрый буст СБ в связи с появлением изучения термалов.
 
:cl:
- tweak: Технология термальных очков перенесена в ветку СБ!
