### PR TITLE
Block telepathy on death

### DIFF
--- a/Content.Server/SS220/Telepathy/TelepathySystem.cs
+++ b/Content.Server/SS220/Telepathy/TelepathySystem.cs
@@ -50,8 +50,13 @@ public sealed class TelepathySystem : EntitySystem
 
     private void OnTelepathySend(Entity<TelepathyComponent> ent, ref TelepathySendEvent args)
     {
-        if (ent.Comp.TelepathyChannelPrototype is { } telepathyChannel)
-            SendMessageToEveryoneWithRightChannel(telepathyChannel, args.Message, ent);
+        if (ent.Comp.TelepathyChannelPrototype is not { } telepathyChannel)
+            return;
+
+        if (!CanSendTelepathy(ent))
+            return;
+
+        SendMessageToEveryoneWithRightChannel(telepathyChannel, args.Message, ent);
     }
 
     /// <summary>
@@ -165,5 +170,12 @@ public sealed class TelepathySystem : EntitySystem
         RaiseLocalEvent(senderUid.Value, nameEv);
         var name = Name(nameEv.Sender);
         return name;
+    }
+
+    private bool CanSendTelepathy(EntityUid sender)
+    {
+        var args = new TelepathySendAttemptEvent(sender, false);
+        RaiseLocalEvent(sender, ref args);
+        return !args.Cancelled;
     }
 }

--- a/Content.Shared/Administration/SharedAdminFrozenSystem.cs
+++ b/Content.Shared/Administration/SharedAdminFrozenSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Speech;
+using Content.Shared.SS220.Telepathy;
 using Content.Shared.Throwing;
 
 namespace Content.Shared.Administration;
@@ -33,6 +34,7 @@ public abstract class SharedAdminFrozenSystem : EntitySystem
         SubscribeLocalEvent<AdminFrozenComponent, ChangeDirectionAttemptEvent>(OnAttempt);
         SubscribeLocalEvent<AdminFrozenComponent, EmoteAttemptEvent>(OnEmoteAttempt);
         SubscribeLocalEvent<AdminFrozenComponent, SpeakAttemptEvent>(OnSpeakAttempt);
+        SubscribeLocalEvent<AdminFrozenComponent, TelepathySendAttemptEvent>(OnTelepathyAttempt); // SS220 Block telepathy on death
     }
 
     private void OnInteractAttempt(Entity<AdminFrozenComponent> ent, ref InteractionAttemptEvent args)
@@ -86,4 +88,12 @@ public abstract class SharedAdminFrozenSystem : EntitySystem
         if (component.Muted)
             args.Cancel();
     }
+
+    // SS220 Block telepathy on death begin
+    private void OnTelepathyAttempt(Entity<AdminFrozenComponent> entity, ref TelepathySendAttemptEvent args)
+    {
+        if (entity.Comp.Muted)
+            args.Cancelled = true;
+    }
+    // SS220 Block telepathy on death end
 }

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -23,6 +23,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Content.Shared.Emoting;
+using Content.Shared.SS220.Telepathy;
 
 namespace Content.Shared.Bed.Sleep;
 
@@ -64,6 +65,7 @@ public sealed partial class SleepingSystem : EntitySystem
         SubscribeLocalEvent<ForcedSleepingComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<SleepingComponent, UnbuckleAttemptEvent>(OnUnbuckleAttempt);
         SubscribeLocalEvent<SleepingComponent, EmoteAttemptEvent>(OnEmoteAttempt);
+        SubscribeLocalEvent<SleepingComponent, TelepathySendAttemptEvent>(OnTelepathyAttempt); // SS220 Block telepathy on death
     }
 
     private void OnUnbuckleAttempt(Entity<SleepingComponent> ent, ref UnbuckleAttemptEvent args)
@@ -318,6 +320,13 @@ public sealed partial class SleepingSystem : EntitySystem
     {
         args.Cancel();
     }
+
+    // SS220 Block telepathy on death begin
+    public void OnTelepathyAttempt(Entity<SleepingComponent> ent, ref TelepathySendAttemptEvent args)
+    {
+        args.Cancelled = true;
+    }
+    // SS220 Block telepathy on death end
 }
 
 

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -1,4 +1,4 @@
-using Content.Shared.Bed.Sleep;
+﻿using Content.Shared.Bed.Sleep;
 using Content.Shared.Buckle.Components;
 using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Damage.ForceSay;

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Bed.Sleep;
+using Content.Shared.Bed.Sleep;
 using Content.Shared.Buckle.Components;
 using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Damage.ForceSay;
@@ -13,6 +13,7 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Pointing;
 using Content.Shared.Pulling.Events;
 using Content.Shared.Speech;
+using Content.Shared.SS220.Telepathy;
 using Content.Shared.Standing;
 using Content.Shared.Strip.Components;
 using Content.Shared.Throwing;
@@ -32,6 +33,7 @@ public partial class MobStateSystem
         SubscribeLocalEvent<MobStateComponent, ConsciousAttemptEvent>(CheckConcious);
         SubscribeLocalEvent<MobStateComponent, ThrowAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, SpeakAttemptEvent>(OnSpeakAttempt);
+        SubscribeLocalEvent<MobStateComponent, TelepathySendAttemptEvent>(OnTelepathyAttempt); // SS220 Block telepathy on death
         SubscribeLocalEvent<MobStateComponent, IsEquippingAttemptEvent>(OnEquipAttempt);
         SubscribeLocalEvent<MobStateComponent, EmoteAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, IsUnequippingAttemptEvent>(OnUnequipAttempt);
@@ -147,6 +149,19 @@ public partial class MobStateSystem
 
         CheckAct(uid, component, args);
     }
+
+    // SS220 Block telepathy on death begin
+    private void OnTelepathyAttempt(Entity<MobStateComponent> entity, ref TelepathySendAttemptEvent args)
+    {
+        switch (entity.Comp.CurrentState)
+        {
+            case MobState.Dead:
+            case MobState.Critical:
+                args.Cancelled = true;
+                break;
+        }
+    }
+    // SS220 Block telepathy on death end
 
     private void CheckAct(EntityUid target, MobStateComponent component, CancellableEntityEventArgs args)
     {

--- a/Content.Shared/SS220/Telepathy/TelepathyComponent.cs
+++ b/Content.Shared/SS220/Telepathy/TelepathyComponent.cs
@@ -42,3 +42,6 @@ public sealed partial class TelepathyAnnouncementSendEvent : InstantActionEvent
         TelepathyChannel = telepathyChannel;
     }
 }
+
+[ByRefEvent]
+public record struct TelepathySendAttemptEvent(EntityUid Sender, bool Cancelled);


### PR DESCRIPTION
## Описание PR

Телепатия больше не может быть использована:
- При смерти/в крите
- Во сне
- При админ фризе + муте

**Медиа**

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl:
- fix: Телепатия больше не может быть использована в критическом состоянии или при смерти.
