### PR TITLE
No AFK on any input

### DIFF
--- a/Content.Client/SS220/Afk/AfkSystem220.cs
+++ b/Content.Client/SS220/Afk/AfkSystem220.cs
@@ -1,0 +1,70 @@
+using Content.Shared.SS220.Afk;
+using Content.Shared.SS220.CCVars;
+using Robust.Client.Input;
+using Robust.Client.UserInterface;
+using Robust.Shared.Configuration;
+using Robust.Shared.Input;
+using Robust.Shared.Timing;
+
+namespace Content.Client.SS220.Afk;
+
+public sealed class AfkSystem220 : EntitySystem
+{
+    [Dependency] private readonly IInputManager _inputManager = default!;
+    [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+
+    private bool _isAnyInput = false;
+    private TimeSpan? _lastActivityMessageTimestamp;
+    private TimeSpan _activityMessageInterval;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _inputManager.UIKeyBindStateChanged += OnUIKeyBindStateChanged;
+        _activityMessageInterval = TimeSpan.FromSeconds(_configurationManager.GetCVar(CCVars220.AfkActivityMessageInterval));
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        // The problem here is that shutdown can be very likely caused by disconnecting from server,
+        // that is caused by clicking the UI button, that is caused by user input and this UIKeyBindStateChanged event,
+        // so this is basically a modifying-collection-inside-iteration case. That is why I use DeferAction, so
+        // unsubscription will happen this or next frame but certainly not inside collection iteration.
+        // Yes, this is not the best solution, but probably the simplest for now.
+        _userInterfaceManager.DeferAction(() =>
+        {
+            _inputManager.UIKeyBindStateChanged -= OnUIKeyBindStateChanged;
+        });
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        // We need to initialize time and turns out that it does not work inside Initialize() call.
+        _lastActivityMessageTimestamp ??= _gameTiming.CurTime;
+
+        if (_gameTiming.CurTime - _lastActivityMessageTimestamp > _activityMessageInterval)
+        {
+            SendActivityMessage();
+        }
+    }
+
+    private bool OnUIKeyBindStateChanged(BoundKeyEventArgs args)
+    {
+        _isAnyInput = true;
+        return false;
+    }
+
+    private void SendActivityMessage()
+    {
+        _lastActivityMessageTimestamp = _gameTiming.CurTime;
+        if (!_isAnyInput)
+            return;
+        RaiseNetworkEvent(new PlayerActivityMessage());
+        _isAnyInput = false;
+    }
+}

--- a/Content.Client/SS220/Afk/AfkSystem220.cs
+++ b/Content.Client/SS220/Afk/AfkSystem220.cs
@@ -1,3 +1,4 @@
+// © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
 using Content.Shared.SS220.Afk;
 using Content.Shared.SS220.CCVars;
 using Robust.Client.Input;

--- a/Content.Server/SS220/Afk/AfkSystem220.cs
+++ b/Content.Server/SS220/Afk/AfkSystem220.cs
@@ -1,0 +1,20 @@
+using Content.Server.Afk;
+using Content.Shared.SS220.Afk;
+
+namespace Content.Server.SS220.Afk;
+
+public sealed class AfkSystem220 : EntitySystem
+{
+    [Dependency] private readonly IAfkManager _afkManager = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeNetworkEvent<PlayerActivityMessage>(OnActivityMessage);
+    }
+
+    private void OnActivityMessage(PlayerActivityMessage message, EntitySessionEventArgs args)
+    {
+        _afkManager.PlayerDidAction(args.SenderSession);
+    }
+}

--- a/Content.Server/SS220/Afk/AfkSystem220.cs
+++ b/Content.Server/SS220/Afk/AfkSystem220.cs
@@ -1,3 +1,4 @@
+// © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
 using Content.Server.Afk;
 using Content.Shared.SS220.Afk;
 

--- a/Content.Shared/SS220/Afk/PlayerActivityMessage.cs
+++ b/Content.Shared/SS220/Afk/PlayerActivityMessage.cs
@@ -1,3 +1,4 @@
+// © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.SS220.Afk;

--- a/Content.Shared/SS220/Afk/PlayerActivityMessage.cs
+++ b/Content.Shared/SS220/Afk/PlayerActivityMessage.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.SS220.Afk;
+
+/// <summary>
+/// "Hey, I am not AFK!" type of message.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class PlayerActivityMessage : EntityEventArgs;

--- a/Content.Shared/SS220/CCVars/CCVars220.cs
+++ b/Content.Shared/SS220/CCVars/CCVars220.cs
@@ -80,6 +80,9 @@ public sealed class CCVars220
     public static readonly CVarDef<float> AfkTeleportToCryo =
         CVarDef.Create("afk.teleport_to_cryo", 1800f, CVar.SERVERONLY);
 
+    public static readonly CVarDef<float> AfkActivityMessageInterval =
+        CVarDef.Create("afk.activity_message_interval", 20f, CVar.CLIENTONLY | CVar.CHEAT);
+
     /// <summary>
     ///     Controls whether the server will deny any players that are not whitelisted in the Prime DB.
     /// </summary>


### PR DESCRIPTION
## Описание PR
Fixes #1137. Клиент теперь прослушивает весь ввод и если за период (20 секунд) была нажата хоть одна клавиша, то отправляет сообщение об активности на сервер, тот не будет кикать игрока за AFK. Ограничение: движение самой мыши и колеса мыши не учитываются.

**Медиа**

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- fix: Сервер больше не отключает игроков по причине неактивности если пользователь производит любой ввод.
