### PR TITLE
[WiP] Minor fauna update

### DIFF
--- a/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.StationEvents.Events;
+using Content.Server.StationEvents.Events;
 using Content.Shared.Storage;
 
 namespace Content.Server.StationEvents.Components;
@@ -14,4 +14,9 @@ public sealed partial class VentCrittersRuleComponent : Component
     /// </summary>
     [DataField("specialEntries")]
     public List<EntitySpawnEntry> SpecialEntries = new();
+
+    //SS220 fauna Update start
+    [DataField("stackAmount")]
+    public int StackAmount = 1;
+    //SS220 fauna update end
 }

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -23,20 +23,33 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
         {
             return;
         }
-
+        //SS220 fauna update
+        if (component.StackAmount == 0)
+        {
+            return;
+        }
+        //SS220 fauna update
         var locations = EntityQueryEnumerator<VentCritterSpawnLocationComponent, TransformComponent>();
         var validLocations = new List<EntityCoordinates>();
+        var counter = 1;
         while (locations.MoveNext(out _, out _, out var transform))
         {
-            if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == station &&
-                HasComp<BecomesStationComponent>(transform.GridUid)) //SS220 Vent critters spawn fix
+            if (counter % component.StackAmount == 0)
             {
-                validLocations.Add(transform.Coordinates);
-                foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom))
+                if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == station &&
+                HasComp<BecomesStationComponent>(transform.GridUid)) //SS220 Vent critters spawn fix
                 {
-                    Spawn(spawn, transform.Coordinates);
+                    validLocations.Add(transform.Coordinates);
+                    foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom))
+                    {
+                        for (var i = 0; i < component.StackAmount; i++) //SS220 fauna Update for loop
+                        {
+                            Spawn(spawn, transform.Coordinates); //This line from offs
+                        }
+                    }
                 }
             }
+            counter = counter + 1;
         }
 
         if (component.SpecialEntries.Count == 0 || validLocations.Count == 0)

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -415,6 +415,7 @@
     weight: 5
     duration: 60
   - type: VentCrittersRule
+    stackAmount: 3
     entries:
     - id: MobGiantSpiderAngry
       prob: 0.05


### PR DESCRIPTION
## Описание PR
Это такой гол.

Работаю над минорной фауной, такой как слаймы и пауки. В планах сделать их интереснее и приятнее для игры.
Постараюсь удержать свое желание повысить им резисты и вместо этого буду фиксить то, что считаю "ошибками разработки" и пытаться добавить уникальные игровые фичи. Единственный стат, который (может быть) подниму в ПРе - стаминаРезист.

**Чуть больше про резисты, статы и фичи:** Моё личное мнение - тем же тарантулам не хватает чуть чуть урона и выживаемости, капитан с саблей перебивает трех пауков, теряя при этом только половину здоровья в условиях где никто не мажет. Статы менять не буду, потому что во-первых новые фичи сделают мобов сильнее, и тогда может не быть нужды бафать цифры. Во-вторых потому что основная проблема текущей минорной фауны это не баланс, а отсутствие того, что я условно назову Role fantasy.

**Моё определение Role fantasy:** Это концепция того, что когда ты берешь определённую роль, существо, расу и тому подобное, у тебя в голове есть неосознанная И осознанная фантазия о том, что эта раса, существо и роль может, как живет и о чем думает. Например, когда ты играешь на слайме, большая часть людей будет согласна в том, что они могут менять форму по своему желанию. И когда слайм этого не может, его Role fantasy не существует, что выводит из атмосферы и заставляет рольку, расу или профессию ощущаться скудно и неинтересно. И это работает как в отношении игрока НА рольке, потому что он не получает тот экспириенс который в теории ожидал, так и людей взаимодействующих С ролькой. Потому что от противостояние слайму, который в теории может менять форму, превращается в отстрел мишеней в текстурке слаймов.

**Мой личный тасклист:**
- [x] Добавить рулю спавна на венте возможность настраивать количество мобов в стаке не меняя количество спавнов за ивент
- [ ] Определить в каких ивентах сколько мобов в стаке и назначить это значение
- [ ] Добавить тарантулам возможность плести стены из паутины
- [ ] Добавить тарантулам возможность связывать в коконы животных и употреблять их кровь в пищу для восстановления
- [ ] Добавить способность тарантулам откладывать яйца за крупную цену в голоде и с огромным КД, при этом способность в кд с спавна
- [ ] Покрутить скорость вскрытия шлюзов у тарантулов
- [ ] Добавить слаймам способность к морфу в слаймышь. 
- [ ] Добавить слаймам способность к морфу в слаймостену
- [ ] Добавить слаймам возможность поглощать тела животных и восстанавливать за счет этого здоровье
- [ ] Добавить слаймам возможность делиться на два за огромную цену в голоде и с огромным КД, способность в кд со спавна
- [ ] Сделать ивентовых кобр гостролями по умолчанию
- [ ] Добавить новый ивент фауны - Мим-слаймы

Тасклист может быть обновлён, потому что веду я его для себя. По силам и возможности буду консультироваться с людьми опытнее на тему того, что и как стоит делать.


**Медиа**

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [ ] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [ ] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [ ] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: kimorue
- add: Добавлено веселье!
- remove: Убрано веселье!
- tweak: Изменено веселье!
- fix: Исправлено веселье!
