### PR TITLE
Wheelchair Size Fix

### DIFF
--- a/Resources/Prototypes/SS220/Entities/Objects/Vehicles/buckleable.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Vehicles/buckleable.yml
@@ -460,3 +460,5 @@
   components:
     - type: Foldable
       folded: true
+    - type: Item
+      size: Huge


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Фикс размера сложенной кресла-коляски, что до этого помещалась даже в карман. Почему то оффы в перент сложенной указали базовый прото сложенного состояния без настройки size компонента.

**Медиа**
![image](https://github.com/user-attachments/assets/8afca5f5-cf6d-4684-8384-ba95366854d8)


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl: ♿ Bomjojuk ♿ 
- tweak: Изменён размер кресла коляски в сложенном состоянии! Теперь она больше не будет помещается в карман. ♿ 