### PR TITLE
ФИКС визуального отображения наушников

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
@@ -10,7 +10,7 @@
     - state: icon
       map: [ "enum.ToggleVisuals.Layer" ]
   - type: Clothing
-    equippedPrefix: off
+    equippedPrefix: on #ss220 fix
     sprite: SS220/Clothing/Neck/Misc/headphones.rsi #SS220HeadphonesResprite
   - type: ToggleableLightVisuals
     spriteLayer: enum.ToggleVisuals.Layer


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
 fix: #2609 

**Медиа**
![image](https://github.com/user-attachments/assets/885ab904-dea9-4655-935f-3ab9461d66ea)
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
🆑 Cortez
- fix: Исправлен баг, при котором наушники не отображались на кукле