### PR TITLE
Исправление частоты обновления ряда панелей BUI

### DIFF
--- a/Content.Client/Atmos/Consoles/AtmosAlertsComputerBoundUserInterface.cs
+++ b/Content.Client/Atmos/Consoles/AtmosAlertsComputerBoundUserInterface.cs
@@ -11,6 +11,8 @@ public sealed class AtmosAlertsComputerBoundUserInterface : BoundUserInterface
 
     protected override void Open()
     {
+        base.Open();
+
         _menu = new AtmosAlertsComputerWindow(this, Owner);
         _menu.OpenCentered();
         _menu.OnClose += Close;

--- a/Content.Client/Instruments/UI/InstrumentBoundUserInterface.cs
+++ b/Content.Client/Instruments/UI/InstrumentBoundUserInterface.cs
@@ -39,6 +39,8 @@ namespace Content.Client.Instruments.UI
 
         protected override void Open()
         {
+            base.Open();
+
             _instrumentMenu = this.CreateWindow<InstrumentMenu>();
             _instrumentMenu.Title = EntMan.GetComponent<MetaDataComponent>(Owner).EntityName;
 

--- a/Content.Client/MassMedia/Ui/NewsWriterBoundUserInterface.cs
+++ b/Content.Client/MassMedia/Ui/NewsWriterBoundUserInterface.cs
@@ -20,6 +20,8 @@ public sealed class NewsWriterBoundUserInterface : BoundUserInterface
 
     protected override void Open()
     {
+        base.Open();
+
         _menu = this.CreateWindow<NewsWriterMenu>();
 
         _menu.ArticleEditorPanel.PublishButtonPressed += OnPublishButtonPressed;

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
@@ -14,6 +14,8 @@ public sealed class CrewMonitoringBoundUserInterface : BoundUserInterface
 
     protected override void Open()
     {
+        base.Open();
+
         EntityUid? gridUid = null;
         var stationName = string.Empty;
 

--- a/Content.Client/Nuke/NukeBoundUserInterface.cs
+++ b/Content.Client/Nuke/NukeBoundUserInterface.cs
@@ -18,6 +18,8 @@ namespace Content.Client.Nuke
 
         protected override void Open()
         {
+            base.Open();
+
             _menu = this.CreateWindow<NukeMenu>();
 
             _menu.OnKeypadButtonPressed += i =>

--- a/Content.Client/Power/PowerMonitoringConsoleBoundUserInterface.cs
+++ b/Content.Client/Power/PowerMonitoringConsoleBoundUserInterface.cs
@@ -12,6 +12,8 @@ public sealed class PowerMonitoringConsoleBoundUserInterface : BoundUserInterfac
 
     protected override void Open()
     {
+        base.Open();
+
         _menu = this.CreateWindow<PowerMonitoringWindow>();
         _menu.SetEntity(Owner);
         _menu.SendPowerMonitoringConsoleMessageAction += SendPowerMonitoringConsoleMessage;

--- a/Content.Client/Store/Ui/StoreBoundUserInterface.cs
+++ b/Content.Client/Store/Ui/StoreBoundUserInterface.cs
@@ -27,6 +27,8 @@ public sealed class StoreBoundUserInterface : BoundUserInterface
 
     protected override void Open()
     {
+        base.Open();
+
         _menu = this.CreateWindow<StoreMenu>();
         if (EntMan.TryGetComponent<StoreComponent>(Owner, out var store))
             _menu.Title = Loc.GetString(store.Name);

--- a/Content.Client/SurveillanceCamera/UI/SurveillanceCameraSetupBoundUi.cs
+++ b/Content.Client/SurveillanceCamera/UI/SurveillanceCameraSetupBoundUi.cs
@@ -21,6 +21,8 @@ public sealed class SurveillanceCameraSetupBoundUi : BoundUserInterface
 
     protected override void Open()
     {
+        base.Open();
+
         _window = new();
 
         if (_type == SurveillanceCameraSetupUiKey.Router)


### PR DESCRIPTION
## Описание PR
Ранее ряд панелей BUI не обновлялся просто потому что у них отсутствовал базовый вызов `base.Open()` в перезаписываемом методе `Open()` (атрибут `[MustCallBase]` появился у этого метода только в RobustToolbox v245.0.0, мы на предыдущей от этого версии, потому такое реально проскочило в кодовую базу визардов). А там содержалась логика, которая давала системе UI понять, что панель открыта, но раз её не было, то и система UI посчитала, что панели никто не открывал, а потому слать обновления не требуется.

Фикс напрямую взят из кодовой базы Space Wizards.

Исправление получили следующие интерфейсы:
- Консоль мониторинга атмосферной сети
- MIDI проигрыватель
- Консоль новостей репортёра
- Консоль мониторинга экипажа
- Ядерная боеголовка
- Консоль мониторинга электросети
- Магазин (аплинк, способности ревенанта, способности мага)
- Консоль камер видео-наблюдения

fix: #2626

**Медиа**
*Нет*

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- fix: Исправлено обновление в реальном времени интерфейсов: Консоль мониторинга экипажа, консоль мониторинга электросети, MIDI проигрыватель, консоль мониторинга атмосферной сети, консоль новостей репортёра, панель ядерной боеголовки, UI магазинов (аплинк, способности ревенанта, мага), консоли камер видеонаблюдения
