### PR TITLE
Fix TTS playing of not visible by PVS entities

### DIFF
--- a/Content.Client/SS220/TTS/TTSSystem.cs
+++ b/Content.Client/SS220/TTS/TTSSystem.cs
@@ -253,7 +253,7 @@ public sealed partial class TTSSystem : EntitySystem
         res.Load(_dependencyCollection, Prefix / filePath);
         _resourceCache.CacheResource(Prefix / filePath, res);
 
-        if (sourceUid == null)
+        if (sourceUid == null || !Exists(sourceUid))
         {
             var soundPath = new SoundPathSpecifier(Prefix / filePath, finalParams);
             _audio.PlayGlobal(soundPath, Filter.Local(), false);
@@ -261,8 +261,7 @@ public sealed partial class TTSSystem : EntitySystem
         }
         else
         {
-            if (sourceUid.HasValue && sourceUid.Value.IsValid())
-                TryQueuePlayById(sourceUid.Value, _fileIdx, finalParams, globally);
+            TryQueuePlayById(sourceUid.Value, _fileIdx, finalParams, globally);
         }
 
         _fileIdx++;


### PR DESCRIPTION
## Описание PR
Исправлено воспроизведение сообщений TTS для сущностей, которые слышать сообщения должны, но не видят сущность (ограничение через PVS, т. е. сущность для них даже не существует).

Звуки от сущностей, которые не доступны со стороны клиента воспроизводятся для клиента глобально, поскольку прикрепить позицию звука к тому, о чём клиент даже не знает - нельзя.

fix: #1902 
**Медиа**

https://github.com/user-attachments/assets/87e22ecb-e7d1-4fdf-b65a-35414b2a924b

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- fix: Исправлено воспроизведение TTS ревенанта для окружающих
