### PR TITLE
Make name and job in PDA crew manifest listing be copyable

### DIFF
--- a/Content.Client/CrewManifest/UI/CrewManifestSection.cs
+++ b/Content.Client/CrewManifest/UI/CrewManifestSection.cs
@@ -48,12 +48,8 @@ public sealed class CrewManifestSection : BoxContainer
                 HorizontalExpand = true
             };
 
-            // SS220-QoL copy name from manifest button-Begin
-            var title = new CopyableRichTextLabel()
-            {
-                Text = entry.JobTitle,
-            };
-            // SS220-QoL copy name from manifest button-End
+            var title = new CopyableRichTextLabel(); // SS220-QoL copy name from manifest button
+            title.SetMessage(entry.JobTitle);
 
             if (prototypeManager.TryIndex<JobIconPrototype>(entry.JobIcon, out var jobIcon))
             {

--- a/Content.Client/CrewManifest/UI/CrewManifestSection.cs
+++ b/Content.Client/CrewManifest/UI/CrewManifestSection.cs
@@ -36,13 +36,11 @@ public sealed class CrewManifestSection : BoxContainer
 
         foreach (var entry in entries)
         {
-            // SS220-QoL copy name from manifest button-Begin
-            var name = new CopyableRichTextLabel()
+            var name = new CopyableRichTextLabel() // SS220-QoL copy name from manifest button
             {
                 HorizontalExpand = true,
-                Text = entry.Name,
             };
-            // SS220-QoL copy name from manifest button-End
+            name.SetMessage(entry.Name);
 
             var titleContainer = new BoxContainer()
             {

--- a/Content.Client/CrewManifest/UI/CrewManifestSection.cs
+++ b/Content.Client/CrewManifest/UI/CrewManifestSection.cs
@@ -5,6 +5,7 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Prototypes;
 using System.Numerics;
 using Content.Shared.Roles;
+using Content.Client.SS220.UserInterface;
 
 namespace Content.Client.CrewManifest.UI;
 
@@ -35,11 +36,13 @@ public sealed class CrewManifestSection : BoxContainer
 
         foreach (var entry in entries)
         {
-            var name = new RichTextLabel()
+            // SS220-QoL copy name from manifest button-Begin
+            var name = new CopyableRichTextLabel()
             {
                 HorizontalExpand = true,
+                Text = entry.Name,
             };
-            name.SetMessage(entry.Name);
+            // SS220-QoL copy name from manifest button-End
 
             var titleContainer = new BoxContainer()
             {
@@ -47,9 +50,12 @@ public sealed class CrewManifestSection : BoxContainer
                 HorizontalExpand = true
             };
 
-            var title = new RichTextLabel();
-            title.SetMessage(entry.JobTitle);
-
+            // SS220-QoL copy name from manifest button-Begin
+            var title = new CopyableRichTextLabel()
+            {
+                Text = entry.JobTitle,
+            };
+            // SS220-QoL copy name from manifest button-End
 
             if (prototypeManager.TryIndex<JobIconPrototype>(entry.JobIcon, out var jobIcon))
             {

--- a/Content.Client/SS220/UserInterface/CopyableRichTextLabel.cs
+++ b/Content.Client/SS220/UserInterface/CopyableRichTextLabel.cs
@@ -1,6 +1,7 @@
 // © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Utility;
 
 namespace Content.Client.SS220.UserInterface;
 
@@ -32,5 +33,15 @@ public sealed partial class CopyableRichTextLabel : ContainerButton
                 clipboard.SetText(Label.Text);
         };
         AddChild(Label);
+    }
+
+    public void SetMessage(FormattedMessage message, Type[]? tagsAllowed = null, Color? defaultColor = null)
+    {
+        Label.SetMessage(message, tagsAllowed, defaultColor);
+    }
+
+    public void SetMessage(string message, Type[]? tagsAllowed = null, Color? defaultColor = null)
+    {
+        Label.SetMessage(message, tagsAllowed, defaultColor);
     }
 }

--- a/Content.Client/SS220/UserInterface/CopyableRichTextLabel.cs
+++ b/Content.Client/SS220/UserInterface/CopyableRichTextLabel.cs
@@ -1,0 +1,36 @@
+// © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+
+namespace Content.Client.SS220.UserInterface;
+
+public sealed partial class CopyableRichTextLabel : ContainerButton
+{
+    [ViewVariables]
+    public string? Text
+    {
+        get => Label.Text;
+        set
+        {
+            if (value != null)
+                Label.SetMessage(value);
+        }
+    }
+    public RichTextLabel Label;
+
+    public CopyableRichTextLabel()
+    {
+        var clipboard = IoCManager.Resolve<IClipboardManager>();
+        Label = new RichTextLabel();
+
+        if (Text != null)
+            Label.SetMessage(Text);
+
+        OnPressed += (args) =>
+        {
+            if (Label.Text != null)
+                clipboard.SetText(Label.Text);
+        };
+        AddChild(Label);
+    }
+}


### PR DESCRIPTION
## Описание PR
Добавляет возможность копировать имена членов экипажа и названия должностей из приложения манифеста в КПК


Выполнено по https://discord.com/channels/1097181193939730453/1359201321873309786

**Медиа**

https://github.com/user-attachments/assets/9ec3b94d-d832-4d56-b31f-afd557296013

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- add: Добавлена возможность копировать имена и названия должностей из приложения манифеста в КПК
