### PR TITLE
Fix DNA copy implant target gib interaction

### DIFF
--- a/Content.Server/SS220/PenScrambler/PenScramblerComponent.cs
+++ b/Content.Server/SS220/PenScrambler/PenScramblerComponent.cs
@@ -6,10 +6,7 @@ namespace Content.Server.SS220.PenScrambler;
 public sealed partial class PenScramblerComponent : Component
 {
     [DataField]
-    public EntityUid? Target;
-
-    [DataField]
-    public HumanoidAppearanceComponent? AppearanceComponent;
+    public EntityUid? NullspaceClone;
 
     [DataField]
     public bool HaveDna = false;

--- a/Content.Server/SS220/PenScrambler/TransferIdentityComponent.cs
+++ b/Content.Server/SS220/PenScrambler/TransferIdentityComponent.cs
@@ -6,8 +6,5 @@ namespace Content.Server.SS220.PenScrambler;
 public sealed partial class TransferIdentityComponent : Component
 {
     [DataField]
-    public EntityUid? Target;
-
-    [DataField]
-    public HumanoidAppearanceComponent? AppearanceComponent;
+    public EntityUid? NullspaceClone;
 }

--- a/Content.Server/SS220/PenScrambler/TransferIdentitySystem.cs
+++ b/Content.Server/SS220/PenScrambler/TransferIdentitySystem.cs
@@ -20,16 +20,14 @@ public sealed class TransferIdentitySystem : EntitySystem
         if (!TryComp<PenScramblerComponent>(args.Target, out var penComponent))
             return;
 
-        if (penComponent.Target == null)
+        if (penComponent.NullspaceClone == null)
             return;
 
-        ent.Comp.Target = penComponent.Target.Value;
-        ent.Comp.AppearanceComponent = penComponent.AppearanceComponent;
+        ent.Comp.NullspaceClone = penComponent.NullspaceClone;
 
         _popup.PopupEntity(Loc.GetString("pen-scrambler-success-transfer-to-implant",
-            ("identity", MetaData(penComponent.Target.Value).EntityName)), args.User, args.User);
+            ("identity", MetaData(penComponent.NullspaceClone.Value).EntityName)), args.User, args.User);
 
-        Dirty(ent);
         QueueDel(args.Target);
     }
 }


### PR DESCRIPTION
## Описание PR
Имплант копирования ДНК опирается на Entity цели что может привести к двум неприятным ситуациям:
- Если цель гибнуть после копирования в ручку, при использовании импланта ничего не происходит.
- Если цели миксануть ДНК после копирования в ручку, при использовании импланта агент превращается в НОВУЮ куклу.

Этот фикс создёт клона цели в nullspace координатах чтобы не привязываться к их кукле. При использовании импланта, копирование производится с этого клона, после чего тот удаляется.

P.S. Убрал ненужный (?) вызов Dirty(), но я пока-что ничего не понимаю в нетворкинге, прошу поревъювить.

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- fix: Имплант копирования ДНК теперь корректно работает даже если цель гибнули
