### PR TITLE
FIX: Practice disabler on suit slot

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -440,6 +440,7 @@
     sprite: Objects/Weapons/Guns/Battery/practice_disabler.rsi
     quickEquip: false
     slots:
+    - suitStorage #ss220 disabler practice on suit slot (#2772)
     - Belt
   - type: Appearance
   - type: MagazineVisuals


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Тренировочный дизейблер нельзя было повешать на спину (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/2772)

**Медиа**


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

no cl
