### PR TITLE
FIX: Dark Reaper shows on Medical Huds

### DIFF
--- a/Content.Client/StatusIcon/StatusIconSystem.cs
+++ b/Content.Client/StatusIcon/StatusIconSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.CCVar;
 using Content.Shared.Ghost;
+using Content.Shared.SS220.DarkReaper;
 using Content.Shared.StatusIcon;
 using Content.Shared.StatusIcon.Components;
 using Content.Shared.Stealth.Components;
@@ -91,6 +92,11 @@ public sealed class StatusIconSystem : SharedStatusIconSystem
 
         if (data.ShowTo != null && !_entityWhitelist.IsValid(data.ShowTo, viewer))
             return false;
+
+        //ss220 fix dark reaper in hud's start
+        if (TryComp<DarkReaperComponent>(ent, out var darkReaper) && !darkReaper.PhysicalForm)
+            return false;
+        //ss220 fix dark reaper in hud's end
 
         return true;
     }


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Темный жнец показывался на худах (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/2643)

**Медиа**

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- fix: Тёмный Жнец теперь не показывается на медицинских худах
