### PR TITLE
FIX: Crusher healing if target is dead

### DIFF
--- a/Content.Shared/Weapons/Marker/SharedDamageMarkerSystem.cs
+++ b/Content.Shared/Weapons/Marker/SharedDamageMarkerSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Damage;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Whitelist;
@@ -17,6 +18,7 @@ public abstract class SharedDamageMarkerSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!; //ss220 fix crusher healing if target is dead (#2645)
 
     public override void Initialize()
     {
@@ -29,6 +31,11 @@ public abstract class SharedDamageMarkerSystem : EntitySystem
     {
         if (component.Marker != args.Used)
             return;
+
+        //ss220 fix crusher healing if target is dead start (#2645)
+        if (_mobState.IsDead(uid))
+            return;
+        //ss220 fix crusher healing if target is dead end (#2645)
 
         args.BonusDamage += component.Damage;
         RemCompDeferred<DamageMarkerComponent>(uid);


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Теперь крушитель не лечит и не снимает метку, если цель мертва (fix: https://github.com/SerbiaStrong-220/space-station-14/issues/2645)

**Медиа**

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- fix: Теперь крушитель не лечит и не снимает свою метку, если цель мертва
