### PR TITLE
ADD: Alert Level in lobby

### DIFF
--- a/Resources/Locale/ru-RU/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/ru-RU/game-ticking/game-ticker.ftl
@@ -8,13 +8,16 @@ game-ticker-delay-start = Начало раунда было отложено н
 game-ticker-pause-start = Начало раунда было приостановлено.
 game-ticker-pause-start-resumed = Отсчёт начала раунда возобновлён.
 game-ticker-player-join-game-message = Добро пожаловать на Космическую Станцию 14! Если вы играете впервые, обязательно нажмите ESC на клавиатуре и прочитайте правила игры, а также не бойтесь просить помощи в "Админ помощь".
+#ss220 add alert level in lobby start
 game-ticker-get-info-text =
     Привет и добро пожаловать в [color=white]Space Station 14![/color]
     Текущий раунд: [color=white]#{ $roundId }[/color]
     Текущее количество игроков: [color=white]{ $playerCount }[/color]
     Текущая карта: [color=white]{ $mapName }[/color]
+    Текущий уровень угрозы: [color={$color}]{ $level }[/color]
     Текущий режим игры: [color=white]{ $gmTitle }[/color]
     >[color=yellow]{ $desc }[/color]
+#ss220 add alert level in lobby end
 game-ticker-get-info-preround-text =
     Привет и добро пожаловать в [color=white]Space Station 14![/color]
     Текущий раунд: [color=white]#{ $roundId }[/color]


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
В лобби добавлен текущий уровень угрозы на станции, если код эпсилон - то показываться будет зелёный.

Ссылка на трекер: https://discord.com/channels/1097181193939730453/1330550203408715799

**Медиа**

![image](https://github.com/user-attachments/assets/4990cdfa-e641-4202-9d69-cd1095c82c2c)
![image](https://github.com/user-attachments/assets/11210e54-2a76-4ec3-87b5-38b4bde51170)


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- add: В лобби теперь отображается текущий уровень угрозы на станции
