### PR TITLE
TWEAK: Change stunprod

### DIFF
--- a/Content.Server/SS220/Stunprod/StunprodSystem.cs
+++ b/Content.Server/SS220/Stunprod/StunprodSystem.cs
@@ -1,0 +1,104 @@
+using Content.Server.Item;
+using Content.Server.Popups;
+using Content.Server.Power.Components;
+using Content.Server.Power.EntitySystems;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Examine;
+using Content.Shared.Item.ItemToggle;
+using Content.Shared.Item.ItemToggle.Components;
+using Content.Shared.PowerCell;
+using Content.Shared.PowerCell.Components;
+using Content.Shared.SS220.Stunprod;
+using Content.Shared.Throwing;
+using Content.Shared.Weapons.Melee.Events;
+
+namespace Content.Server.SS220.Stunprod;
+
+public sealed class StunprodSystem : SharedStunprodSystem
+{
+    [Dependency] private readonly ItemToggleSystem _itemToggle = default!;
+    [Dependency] private readonly ItemSystem _item = default!;
+    [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly BatterySystem _battery = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<StunprodComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<StunprodComponent, ItemToggledEvent>(OnItemToggled);
+        SubscribeLocalEvent<StunprodComponent, ItemToggleActivateAttemptEvent>(OnActivateAttempt);
+        SubscribeLocalEvent<StunprodComponent, MeleeHitEvent>(OnMeleeHit);
+        SubscribeLocalEvent<StunprodComponent, ThrowDoHitEvent>(OnThrowHit);
+        SubscribeLocalEvent<StunprodComponent, PowerCellSlotEmptyEvent>(OnRemoveBattery);
+    }
+
+    private void OnExamined(Entity<StunprodComponent> ent, ref ExaminedEvent args)
+    {
+        var onMsg = _itemToggle.IsActivated(ent.Owner)
+            ? Loc.GetString("comp-stunbaton-examined-on")
+            : Loc.GetString("comp-stunbaton-examined-off");
+
+        args.PushMarkup(onMsg);
+
+        if (FindBattery(ent) == null)
+            return;
+
+        var count = (int) (FindBattery(ent)!.CurrentCharge / ent.Comp.EnergyPerUse);
+        args.PushMarkup(Loc.GetString("melee-battery-examine", ("color", "yellow"), ("count", count)));
+    }
+
+    private void OnItemToggled(Entity<StunprodComponent> entity, ref ItemToggledEvent args)
+    {
+        _item.SetHeldPrefix(entity.Owner, args.Activated ? "on" : "off");
+    }
+
+    private void OnActivateAttempt(Entity<StunprodComponent> ent, ref ItemToggleActivateAttemptEvent args)
+    {
+        if (FindBattery(ent) != null && !(FindBattery(ent)!.CurrentCharge < ent.Comp.EnergyPerUse))
+            return;
+
+        if (args.User != null)
+            _popup.PopupEntity(Loc.GetString("stunbaton-component-low-charge"), args.User.Value, args.User.Value);
+
+        args.Cancelled = true;
+    }
+
+    private void OnMeleeHit(Entity<StunprodComponent> ent, ref MeleeHitEvent args)
+    {
+        ChangeEnergy(ent);
+    }
+
+    private void OnThrowHit(Entity<StunprodComponent> ent, ref ThrowDoHitEvent args)
+    {
+        ChangeEnergy(ent);
+    }
+
+    private void OnRemoveBattery(Entity<StunprodComponent> ent, ref PowerCellSlotEmptyEvent args)
+    {
+        _itemToggle.TryDeactivate(ent.Owner);
+    }
+
+    private BatteryComponent? FindBattery(Entity<StunprodComponent> ent)
+    {
+        if (!TryComp<PowerCellSlotComponent>(ent.Owner, out var cellSlot)
+            || !_itemSlots.TryGetSlot(ent.Owner, cellSlot.CellSlotId, out var itemSlot)
+            || !TryComp<BatteryComponent>(itemSlot.Item, out var batteryComponent))
+            return null;
+
+        return batteryComponent;
+    }
+
+    private void ChangeEnergy(Entity<StunprodComponent> ent)
+    {
+        if (FindBattery(ent) == null)
+            return;
+
+        if (!_itemToggle.IsActivated(ent.Owner))
+            return;
+
+        if(!_battery.TryUseCharge(FindBattery(ent)!.Owner, ent.Comp.EnergyPerUse))
+            _itemToggle.TryDeactivate(ent.Owner);
+    }
+}

--- a/Content.Shared/SS220/Stunprod/SharedStunprodSystem.cs
+++ b/Content.Shared/SS220/Stunprod/SharedStunprodSystem.cs
@@ -1,0 +1,5 @@
+namespace Content.Shared.SS220.Stunprod;
+
+public abstract class SharedStunprodSystem : EntitySystem
+{
+}

--- a/Content.Shared/SS220/Stunprod/StunprodComponent.cs
+++ b/Content.Shared/SS220/Stunprod/StunprodComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.SS220.Stunprod;
+
+[RegisterComponent]
+[NetworkedComponent]
+public sealed partial class StunprodComponent : Component
+{
+    [DataField]
+    public float CurrentCharge;
+
+    [DataField(required:true)]
+    public float EnergyPerUse;
+}

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -34,8 +34,12 @@
       types:
         Blunt: 0 #ss220 stunprod fix
         Stamina: 35 #ss220 stunprod fix
-  - type: Stunbaton
+  #ss220 change stunprod start
+  #- type: Stunbaton
+    #energyPerUse: 120
+  - type: Stunprod
     energyPerUse: 120
+  #ss220 change stunprod end
   - type: MeleeWeapon
     wideAnimationRotation: -135
     damage:
@@ -60,9 +64,11 @@
         Stamina: 35
   #ss220 stunprod stamina damage fix end
   - type: LandAtCursor # it deals stamina damage when thrown
-  - type: Battery
-    maxCharge: 360
-    startingCharge: 360
+  #ss220 change stunprod start
+  #- type: Battery
+    #maxCharge: 360
+    #startingCharge: 360
+  #ss220 change stunprod end
   - type: UseDelay
   - type: Item
     heldPrefix: off
@@ -86,3 +92,14 @@
   - type: Construction
     graph: makeshiftstunprod
     node: msstunprod
+  #ss220 change stunprod start
+  - type: ContainerContainer
+    containers:
+      cell_slot: !type:ContainerSlot {}
+  - type: PowerCellSlot
+    cellSlotId: cell_slot
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+  #ss220 change stunprod end

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/makeshiftstunprod.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/makeshiftstunprod.yml
@@ -8,11 +8,11 @@
           steps:
             - material: MetalRod
               amount: 1
-            - tag: PowerCellSmall
-              name: power cell small
-              icon:
-                sprite: Objects/Power/power_cells.rsi
-                state: small
+            #- tag: PowerCellSmall
+              #name: power cell small
+              #icon:
+                #sprite: Objects/Power/power_cells.rsi
+                #state: small
             - tag: Handcuffs
               icon:
                 sprite: Objects/Misc/cablecuffs.rsi
@@ -27,4 +27,4 @@
               doAfter: 15
     - node: msstunprod
       entity: Stunprod
-      
+


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Немного поменял станпрод, теперь у него отдельная система, пришлось так сделать, ибо разное применение батареи в отличии от станбатона. Теперь станпроду можно прикрутить любую батарейку. И при крафте не нужна будет батарейка, при этом она вставляется уже после крафта.

**Медиа**

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- tweak: Теперь в крафте самодельного станбатона не нужна батарейка
- tweak: Теперь в самодельный станбатон можно вставить любую батарейку
