### PR TITLE
ADD: Plasteel and RGlass in borg module

### DIFF
--- a/Resources/Locale/ru-RU/ss220/prototypes/entities/objects/materials/sheets/sheets.ftl
+++ b/Resources/Locale/ru-RU/ss220/prototypes/entities/objects/materials/sheets/sheets.ftl
@@ -1,0 +1,7 @@
+ent-SheetPlasteelLingering0 = { ent-SheetPlasteel }
+    .suffix = Не исчезают закончившись, 0
+    .desc = { ent-SheetPlasteel.desc }
+
+ent-SheetRGlassLingering0 = { ent-SheetRGlass }
+    .suffix = Не исчезают закончившись, 0
+    .desc = { ent-SheetRGlass.desc }

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -277,6 +277,10 @@
   - type: ItemBorgModule
     items:
     - SheetSteelLingering0
+    #ss220 add plasteel and rglass for borg module start
+    - SheetPlasteelLingering0
+    - SheetRGlassLingering0
+    #ss220 add plasteel and rglass for borg module end
     - SheetGlassLingering0
     - PartRodMetalLingering0
     - FloorTileItemSteelLingering0

--- a/Resources/Prototypes/SS220/Entities/Objects/Materials/Sheets/plasteel.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Materials/Sheets/plasteel.yml
@@ -1,0 +1,8 @@
+- type: entity
+  parent: SheetPlasteel
+  id: SheetPlasteelLingering0
+  suffix: Lingering, 0
+  components:
+  - type: Stack
+    lingering: true
+    count: 0

--- a/Resources/Prototypes/SS220/Entities/Objects/Materials/Sheets/rglass.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Materials/Sheets/rglass.yml
@@ -1,0 +1,8 @@
+- type: entity
+  parent: SheetRGlass
+  id: SheetRGlassLingering0
+  suffix: Lingering, 0
+  components:
+  - type: Stack
+    lingering: true
+    count: 0


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Теперь в модуле инженерного борга появились два слота под бронестекло и пласталь

(п.2.1 https://discord.com/channels/1158128815311171638/1333840354310492222/1333841278424584294)

**Медиа**

![image](https://github.com/user-attachments/assets/725b3e2c-eed9-4d96-ae34-57aca452ea0a)


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- add: В инженерный модуль борга добавлены два слота под пласталь и бронестекло
