### PR TITLE
Remove deathrattle functionality from tracking implants (#35995)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -142,7 +142,7 @@
   parent: BaseSubdermalImplant
   id: TrackingImplant
   name: tracking implant
-  description: This implant has a tracking device attached to the suit sensor network.
+  description: This implant has a tracking device attached to the suit sensor network, as well as a condition monitor for the Security radio channel.
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
@@ -190,6 +190,14 @@
         - TraitorRole
         - NukeOperative
       # hidden-desc-end
+# SS220-Trackers DeathRattle-End
+    - type: TriggerOnMobstateChange
+      mobState:
+      - Critical
+    - type: Rattle
+      radioChannel: "Security"
+# SS220-Trackers DeathRattle-End
+
 #Traitor implants
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -142,7 +142,7 @@
   parent: BaseSubdermalImplant
   id: TrackingImplant
   name: tracking implant
-  description: This implant has a tracking device attached to the suit sensor network, as well as a condition monitor for the Security radio channel.
+  description: This implant has a tracking device attached to the suit sensor network.
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -190,7 +190,7 @@
         - TraitorRole
         - NukeOperative
       # hidden-desc-end
-# SS220-Trackers DeathRattle-End
+# SS220-Trackers DeathRattle-Start
     - type: TriggerOnMobstateChange
       mobState:
       - Critical


### PR DESCRIPTION
## Описание PR
Нашёл минутку на такой простой PR.

Простой реверт, но с добавлением комментариев SS20 к удалённому коду.

Зачем? Почему? У нас вокруг этой функции имплантов построен геймплей роли офицера Синего Щита, без функции оповещения от имплантов Синий Щит автоматически прикован к консоли мониторинга, потому что отойти от неё без уверенности, что через секунду кто-нибудь не сдохнет и ты этого не увидишь - нет. А при таком раскладе Синий Щит ещё меньше отличается от парамедика.

**Медиа**
*No Media*

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl:
- tweak: Отмена удаления функции оповещения импланта трекера
