### PR TITLE
ADD: Slowness and Nervousness traits

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -557,9 +557,22 @@ namespace Content.Client.Lobby.UI
                     var trait = _prototypeManager.Index<TraitPrototype>(traitProto);
                     var selector = new TraitPreferenceSelector(trait);
 
+                    //ss220 add traits start
+                    var isBlocked = trait.MutuallyExclusiveWith?.Any(conflictId =>
+                        Profile?.TraitPreferences.Contains(conflictId) == true) == true;
+                    //ss220 add traits end
+
                     selector.Preference = Profile?.TraitPreferences.Contains(trait.ID) == true;
                     if (selector.Preference)
                         selectionCount += trait.Cost;
+
+                    //ss220 add traits start
+                    if (isBlocked && !selector.Preference)
+                    {
+                        selector.Checkbox.Disabled = true;
+                        selector.Checkbox.Label.FontColorOverride = Color.DarkGray;
+                    }
+                    //ss220 add traits end
 
                     selector.PreferenceChanged += preference =>
                     {

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
@@ -3,8 +3,7 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Physics;
-using Content.Shared.Popups;
-using Content.Shared.SS220.ChangeSpeedDoAfters;
+using Content.Shared.SS220.ChangeSpeedDoAfters.Events;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.DoAfter;
@@ -15,7 +14,6 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
     [Dependency] private readonly SharedGravitySystem _gravity = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
-    [Dependency] private readonly SharedPopupSystem _popup = default!; //ss220 add traits start
 
     private DoAfter[] _doAfters = Array.Empty<DoAfter>();
 
@@ -55,23 +53,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
             var doAfter = _doAfters[i];
 
             //ss220 add traits start
-            if (TryComp<ChangeSpeedDoAftersComponent>(doAfter.Args.User, out var changeSpeedDoAfters)
-                && changeSpeedDoAfters.ChanceToFail != null)
-            {
-                if (changeSpeedDoAfters.ScheduledCancelTimes.TryGetValue(doAfter.Index, out var cancelTime))
-                {
-                    if (time - doAfter.StartTime >= cancelTime)
-                    {
-                        comp.DoAfters.Remove(doAfter.Index);
-                        changeSpeedDoAfters.ScheduledCancelTimes.Remove(doAfter.Index);
-
-                        _popup.PopupEntity(Loc.GetString("trait-nervousness-popup"), doAfter.Args.User, doAfter.Args.User);
-
-                        dirty = true;
-                        continue;
-                    }
-                }
-            }
+            RaiseLocalEvent(doAfter.Args.User, new DoAfterUpdateEvent(doAfter.StartTime, doAfter.Index), true);
             //ss220 add traits start
 
             if (doAfter.CancelledTime != null)

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -199,7 +199,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         id = new DoAfterId(args.User, comp.NextId++);
 
         //ss220 add traits start
-        RaiseLocalEvent(args.User, new DoAfterProccessEvent(args, id.Value.Index), true);
+        RaiseLocalEvent(args.User, new BeforeDoAfterStartEvent(args, id.Value.Index), true);
         //ss220 add traits end
 
         var doAfter = new DoAfter(id.Value.Index, args, GameTiming.CurTime);

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -4,10 +4,10 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Damage;
 using Content.Shared.Hands.Components;
 using Content.Shared.SS220.ChangeSpeedDoAfters;
+using Content.Shared.SS220.ChangeSpeedDoAfters.Events;
 using Content.Shared.Tag;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -20,7 +20,6 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly TagSystem _tag = default!;
-    [Dependency] private readonly IRobustRandom _random = default!; //ss220 add traits
 
     /// <summary>
     ///     We'll use an excess time so stuff like finishing effects can show.
@@ -200,20 +199,8 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         id = new DoAfterId(args.User, comp.NextId++);
 
         //ss220 add traits start
-        if (TryComp<ChangeSpeedDoAftersComponent>(args.User, out var changeSpeedDoAfters))
-        {
-            args.Delay *= changeSpeedDoAfters.Coefficient;
-
-            if (changeSpeedDoAfters.ChanceToFail != null)
-            {
-                if (_random.Prob(changeSpeedDoAfters.ChanceToFail.Value))
-                {
-                    var cancelTime = TimeSpan.FromSeconds(_random.NextFloat(0, (float)args.Delay.TotalSeconds));
-                    changeSpeedDoAfters.ScheduledCancelTimes[id.Value.Index] = cancelTime;
-                }
-            }
-        }
-        //ss220 add traits start
+        RaiseLocalEvent(args.User, new DoAfterProccessEvent(args, id.Value.Index), true);
+        //ss220 add traits end
 
         var doAfter = new DoAfter(id.Value.Index, args, GameTiming.CurTime);
 

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -695,16 +695,38 @@ namespace Content.Shared.Preferences
             // Track points count for each group.
             var groups = new Dictionary<string, int>();
             var result = new List<ProtoId<TraitPrototype>>();
+            var selectedTraits = new HashSet<ProtoId<TraitPrototype>>(); //ss220 add traits
 
             foreach (var trait in traits)
             {
                 if (!protoManager.TryIndex(trait, out var traitProto))
                     continue;
 
+                //ss220 add traits start
+                var isExcluded = false;
+                if (traitProto.MutuallyExclusiveWith != null)
+                {
+                    foreach (var excluded in traitProto.MutuallyExclusiveWith)
+                    {
+                        var proto = protoManager.Index<TraitPrototype>(excluded);
+
+                        if (!selectedTraits.Contains(proto))
+                            continue;
+
+                        isExcluded = true;
+                        break;
+                    }
+                }
+
+                if (isExcluded)
+                    continue;
+                //ss220 add traits end
+
                 // Always valid.
                 if (traitProto.Category == null)
                 {
                     result.Add(trait);
+                    selectedTraits.Add(trait); //ss220 add traits
                     continue;
                 }
 
@@ -721,6 +743,7 @@ namespace Content.Shared.Preferences
 
                 groups[category.ID] = existing;
                 result.Add(trait);
+                selectedTraits.Add(trait); //ss220 add traits
             }
 
             return result;

--- a/Content.Shared/SS220/ChangeSpeedDoAfters/ChangeSpeedDoAftersComponent.cs
+++ b/Content.Shared/SS220/ChangeSpeedDoAfters/ChangeSpeedDoAftersComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.SS220.ChangeSpeedDoAfters;
+
+[RegisterComponent]
+[NetworkedComponent]
+public sealed partial class ChangeSpeedDoAftersComponent : Component
+{
+    [DataField]
+    public float Coefficient;
+
+    [DataField]
+    public float? ChanceToFail;
+
+    public Dictionary<int, TimeSpan> ScheduledCancelTimes = new();
+}

--- a/Content.Shared/SS220/ChangeSpeedDoAfters/ChangeSpeedDoAftersSystem.cs
+++ b/Content.Shared/SS220/ChangeSpeedDoAfters/ChangeSpeedDoAftersSystem.cs
@@ -15,11 +15,11 @@ public sealed class ChangeSpeedDoAftersSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<ChangeSpeedDoAftersComponent, DoAfterProccessEvent>(OnDoAfterProccess);
+        SubscribeLocalEvent<ChangeSpeedDoAftersComponent, BeforeDoAfterStartEvent>(OnDoAfterProccess);
         SubscribeLocalEvent<ChangeSpeedDoAftersComponent, DoAfterUpdateEvent>(OnDoAfterUpdate);
     }
 
-    private void OnDoAfterProccess(Entity<ChangeSpeedDoAftersComponent> ent, ref DoAfterProccessEvent args)
+    private void OnDoAfterProccess(Entity<ChangeSpeedDoAftersComponent> ent, ref BeforeDoAfterStartEvent args)
     {
         args.Args.Delay *= ent.Comp.Coefficient;
 

--- a/Content.Shared/SS220/ChangeSpeedDoAfters/ChangeSpeedDoAftersSystem.cs
+++ b/Content.Shared/SS220/ChangeSpeedDoAfters/ChangeSpeedDoAftersSystem.cs
@@ -1,0 +1,51 @@
+using Content.Shared.DoAfter;
+using Content.Shared.Popups;
+using Content.Shared.SS220.ChangeSpeedDoAfters.Events;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.SS220.ChangeSpeedDoAfters;
+
+public sealed class ChangeSpeedDoAftersSystem : EntitySystem
+{
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ChangeSpeedDoAftersComponent, DoAfterProccessEvent>(OnDoAfterProccess);
+        SubscribeLocalEvent<ChangeSpeedDoAftersComponent, DoAfterUpdateEvent>(OnDoAfterUpdate);
+    }
+
+    private void OnDoAfterProccess(Entity<ChangeSpeedDoAftersComponent> ent, ref DoAfterProccessEvent args)
+    {
+        args.Args.Delay *= ent.Comp.Coefficient;
+
+        if (ent.Comp.ChanceToFail == null)
+            return;
+
+        if (!_random.Prob(ent.Comp.ChanceToFail.Value))
+            return;
+
+        var cancelTime = TimeSpan.FromSeconds(_random.NextFloat(0, (float)args.Args.Delay.TotalSeconds));
+        ent.Comp.ScheduledCancelTimes[args.Id] = cancelTime;
+    }
+
+    private void OnDoAfterUpdate(Entity<ChangeSpeedDoAftersComponent> ent, ref DoAfterUpdateEvent args)
+    {
+        if (!ent.Comp.ScheduledCancelTimes.TryGetValue(args.Index, out var cancelTime))
+            return;
+
+        var elapsed = _timing.CurTime - args.StartTime;
+
+        if (elapsed < cancelTime)
+            return;
+
+        _doAfter.Cancel(ent.Owner, args.Index);
+        ent.Comp.ScheduledCancelTimes.Remove(args.Index);
+
+        _popup.PopupEntity(Loc.GetString("trait-nervousness-popup"), ent.Owner, ent.Owner);
+    }
+}

--- a/Content.Shared/SS220/ChangeSpeedDoAfters/Events/ChangeSpeedDoAftersEvent.cs
+++ b/Content.Shared/SS220/ChangeSpeedDoAfters/Events/ChangeSpeedDoAftersEvent.cs
@@ -23,12 +23,12 @@ public sealed partial class DoAfterUpdateEvent : EntityEventArgs
 /// This event raised only on start DoAfter
 /// </summary>
 [Serializable, NetSerializable]
-public sealed partial class DoAfterProccessEvent : EntityEventArgs
+public sealed partial class BeforeDoAfterStartEvent : EntityEventArgs
 {
     public DoAfterArgs Args;
     public ushort Id;
 
-    public DoAfterProccessEvent(DoAfterArgs args, ushort id)
+    public BeforeDoAfterStartEvent(DoAfterArgs args, ushort id)
     {
         Args = args;
         Id = id;

--- a/Content.Shared/SS220/ChangeSpeedDoAfters/Events/ChangeSpeedDoAftersEvent.cs
+++ b/Content.Shared/SS220/ChangeSpeedDoAfters/Events/ChangeSpeedDoAftersEvent.cs
@@ -1,0 +1,36 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.SS220.ChangeSpeedDoAfters.Events;
+
+/// <summary>
+/// This event raised every frameTime on user
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class DoAfterUpdateEvent : EntityEventArgs
+{
+    public TimeSpan StartTime;
+    public ushort Index;
+
+    public DoAfterUpdateEvent(TimeSpan startTime, ushort index)
+    {
+        StartTime = startTime;
+        Index = index;
+    }
+}
+
+/// <summary>
+/// This event raised only on start DoAfter
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class DoAfterProccessEvent : EntityEventArgs
+{
+    public DoAfterArgs Args;
+    public ushort Id;
+
+    public DoAfterProccessEvent(DoAfterArgs args, ushort id)
+    {
+        Args = args;
+        Id = id;
+    }
+}

--- a/Content.Shared/Traits/TraitPrototype.cs
+++ b/Content.Shared/Traits/TraitPrototype.cs
@@ -63,5 +63,10 @@ public sealed partial class TraitPrototype : IPrototype
     public ProtoId<TraitCategoryPrototype>? Category;
 
     [DataField]
-    public List<LanguageDefinition> LearnedLanguages = new(); // SS220-Add-Languages 
+    public List<LanguageDefinition> LearnedLanguages = new(); // SS220-Add-Languages
+
+    //ss220 add traits start
+    [DataField]
+    public List<string>? MutuallyExclusiveWith { get; private set; }
+    //ss220 add traits end
 }

--- a/Resources/Locale/ru-RU/ss220/traits/traits.ftl
+++ b/Resources/Locale/ru-RU/ss220/traits/traits.ftl
@@ -1,0 +1,7 @@
+trait-slowness-name = Медлительность
+trait-slowness-desc = Все ваши действия будут занимать немного больше времени, чем обычно.
+
+trait-nervousness-name = Нервозность
+trait-nervousness-desc = Вы действуете быстрее, чем обычно, но иногда теряете концентрацию и прерываете начатое.
+
+trait-nervousness-popup = У вас затряслись руки

--- a/Resources/Prototypes/SS220/Traits/disabilities.yml
+++ b/Resources/Prototypes/SS220/Traits/disabilities.yml
@@ -3,6 +3,8 @@
   name: trait-slowness-name
   description: trait-slowness-desc
   category: Disabilities
+  mutuallyExclusiveWith:
+    - Nervousness
   components:
   - type: ChangeSpeedDoAfters
     coefficient: 1.3
@@ -11,6 +13,8 @@
   id: Nervousness
   name: trait-nervousness-name
   description: trait-nervousness-desc
+  mutuallyExclusiveWith:
+    - Slowness
   category: Disabilities
   components:
   - type: ChangeSpeedDoAfters

--- a/Resources/Prototypes/SS220/Traits/disabilities.yml
+++ b/Resources/Prototypes/SS220/Traits/disabilities.yml
@@ -1,0 +1,18 @@
+- type: trait
+  id: Slowness
+  name: trait-slowness-name
+  description: trait-slowness-desc
+  category: Disabilities
+  components:
+  - type: ChangeSpeedDoAfters
+    coefficient: 1.3
+
+- type: trait
+  id: Nervousness
+  name: trait-nervousness-name
+  description: trait-nervousness-desc
+  category: Disabilities
+  components:
+  - type: ChangeSpeedDoAfters
+    coefficient: 0.7
+    chanceToFail: 0.27

--- a/Resources/Prototypes/SS220/trait_after_death.yml
+++ b/Resources/Prototypes/SS220/trait_after_death.yml
@@ -14,4 +14,6 @@
     Blindness: 0.15
     Muted: 0.15
     Narcolepsy: 0.3
+    Slowness: 0.45
+    Nervousness: 0.45
     # WheelchairBound: 0.05 # Removed bcz req wheelchair spawnfix


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Добавлены два трейта: Медленность и Нервозность. Первый увеличивает все дуАфтеры на 1.3, а второй наоборот, уменьшает дуАфтеры до 0.7, но при этом есть 27% шанс прервать сам дуАфтер.

Так же, добавил List для взаимоисключающихся трейтов

**Медиа**


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- add: Добавлен новый трейт "Медленность". Замедляет все взаимодействия на 30%.
- add: Добавлен новый трейт "Нервозность". Ускоряет все взаимодействия на 30%, но при этом есть 27% шанс оборвать действие.
