### PR TITLE
FIX: Origami damage w/o glasses

### DIFF
--- a/Content.Shared/SS220/OrigamiBook/OrigamiWeaponComponent.cs
+++ b/Content.Shared/SS220/OrigamiBook/OrigamiWeaponComponent.cs
@@ -18,4 +18,12 @@ public sealed partial class OrigamiWeaponComponent : Component
 
     [DataField]
     public float ThrowSpeedIncrease;
+
+    [DataField]
+    public List<string> BlockerSlots = new()
+    {
+        "eyes",
+        "mask",
+        "head",
+    };
 }

--- a/Content.Shared/SS220/OrigamiBook/SharedOrigamiSystem.cs
+++ b/Content.Shared/SS220/OrigamiBook/SharedOrigamiSystem.cs
@@ -1,9 +1,11 @@
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.IdentityManagement.Components;
+using Content.Shared.Inventory;
 using Content.Shared.Popups;
 using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
+using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Random;
 using Robust.Shared.Serialization;
 
@@ -15,6 +17,8 @@ public abstract class SharedOrigamiSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly SharedGunSystem _gun = default!;
 
     public override void Initialize()
     {
@@ -38,8 +42,15 @@ public abstract class SharedOrigamiSystem : EntitySystem
         if (!HasComp<OrigamiUserComponent>(args.Component.Thrower))
             return;
 
-        if (TryComp<IdentityBlockerComponent>(args.Target, out var identityBlocker)
-            && identityBlocker.Coverage is IdentityBlockerCoverage.EYES or IdentityBlockerCoverage.FULL)
+        if (_gun.TryGetGun(args.Component.Thrower.Value, out _, out _))
+            return;
+
+        var hasEyeProtection =
+            _inventory.TryGetSlotEntity(args.Target, "eyes", out var eyes) && IsEyeBlocker(eyes.Value) ||
+            _inventory.TryGetSlotEntity(args.Target, "mask", out var mask) && IsEyeBlocker(mask.Value) ||
+            _inventory.TryGetSlotEntity(args.Target, "head", out var head) && IsEyeBlocker(head.Value);
+
+        if (hasEyeProtection)
         {
             _damageable.TryChangeDamage(args.Target, ent.Comp.Damage);
             return;
@@ -47,6 +58,12 @@ public abstract class SharedOrigamiSystem : EntitySystem
 
         _damageable.TryChangeDamage(args.Target, ent.Comp.DamageWithoutGlasses);
         _stun.TryParalyze(args.Target, TimeSpan.FromSeconds(ent.Comp.TimeParalyze), true);
+    }
+
+    private bool IsEyeBlocker(EntityUid uid)
+    {
+        return TryComp<IdentityBlockerComponent>(uid, out var comp) &&
+               comp.Coverage is IdentityBlockerCoverage.EYES or IdentityBlockerCoverage.FULL;
     }
 
     private void OnDoAfter(StartLearnOrigamiDoAfter args)

--- a/Content.Shared/SS220/OrigamiBook/SharedOrigamiSystem.cs
+++ b/Content.Shared/SS220/OrigamiBook/SharedOrigamiSystem.cs
@@ -45,10 +45,17 @@ public abstract class SharedOrigamiSystem : EntitySystem
         if (_gun.TryGetGun(args.Component.Thrower.Value, out _, out _))
             return;
 
-        var hasEyeProtection =
-            _inventory.TryGetSlotEntity(args.Target, "eyes", out var eyes) && IsEyeBlocker(eyes.Value) ||
-            _inventory.TryGetSlotEntity(args.Target, "mask", out var mask) && IsEyeBlocker(mask.Value) ||
-            _inventory.TryGetSlotEntity(args.Target, "head", out var head) && IsEyeBlocker(head.Value);
+        var hasEyeProtection = false;
+
+        foreach (var slot in ent.Comp.BlockerSlots)
+        {
+            if (!_inventory.TryGetSlotEntity(args.Target, slot, out var slotEntity)
+                || !IsEyeBlocker(slotEntity.Value))
+                continue;
+
+            hasEyeProtection = true;
+            break;
+        }
 
         if (hasEyeProtection)
         {


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Теперь оригами правильно наносит урон, если цель с очками и без, а так же теперь нельзя наносить урон если стреляют из пушки самолетиками.

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

no cl
