### PR TITLE
TWEAK: Filter Telepathy channel for normal player

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -556,7 +556,9 @@ public sealed class ChatUIController : UIController
         }
 
         //ss220 add hidden channel for telepathy for normal player start
-        var hasTelepathy = EntityManager.HasComponent<TelepathyComponent>(_player.LocalSession!.AttachedEntity);
+        var hasTelepathy = _player.LocalSession?.AttachedEntity is {} entityUid
+                           && EntityManager.HasComponent<TelepathyComponent>(entityUid);
+
         var isAdmin = _admin.HasFlag(AdminFlags.Admin) || _admin.HasFlag(AdminFlags.Adminchat);
 
         if (hasTelepathy || isAdmin)

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -24,6 +24,7 @@ using Content.Shared.Decals;
 using Content.Shared.Input;
 using Content.Shared.Radio;
 using Content.Shared.Roles.RoleCodeword;
+using Content.Shared.SS220.Telepathy;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
@@ -535,7 +536,6 @@ public sealed class ChatUIController : UIController
             FilterableChannels |= ChatChannel.Radio;
             FilterableChannels |= ChatChannel.Emotes;
             FilterableChannels |= ChatChannel.Notifications;
-            FilterableChannels |= ChatChannel.Telepathy; //ss220 telepathy
 
             // Can only send local / radio / emote when attached to a non-ghost entity.
             // TODO: this logic is iffy (checking if controlling something that's NOT a ghost), is there a better way to check this?
@@ -545,7 +545,6 @@ public sealed class ChatUIController : UIController
                 CanSendChannels |= ChatSelectChannel.Whisper;
                 CanSendChannels |= ChatSelectChannel.Radio;
                 CanSendChannels |= ChatSelectChannel.Emotes;
-                CanSendChannels |= ChatSelectChannel.Telepathy; //ss220 telepathy
             }
         }
 
@@ -556,14 +555,23 @@ public sealed class ChatUIController : UIController
             CanSendChannels |= ChatSelectChannel.Dead;
         }
 
-        // only admins can see / filter asay
-        if (_admin.HasFlag(AdminFlags.Admin) || _admin.HasFlag(AdminFlags.Adminchat))
+        //ss220 add hidden channel for telepathy for normal player start
+        var hasTelepathy = EntityManager.HasComponent<TelepathyComponent>(_player.LocalSession!.AttachedEntity);
+        var isAdmin = _admin.HasFlag(AdminFlags.Admin) || _admin.HasFlag(AdminFlags.Adminchat);
+
+        if (hasTelepathy || isAdmin)
         {
-            FilterableChannels |= ChatChannel.Admin;
-            FilterableChannels |= ChatChannel.AdminAlert;
-            FilterableChannels |= ChatChannel.AdminChat;
+            FilterableChannels |= ChatChannel.Telepathy;
+            CanSendChannels |= ChatSelectChannel.Telepathy;
+        }
+
+        // only admins can see / filter asay
+        if (isAdmin)
+        {
+            FilterableChannels |= ChatChannel.Admin | ChatChannel.AdminAlert | ChatChannel.AdminChat;
             CanSendChannels |= ChatSelectChannel.Admin;
         }
+        //ss220 add hidden channel for telepathy for normal player end
 
         SelectableChannels = CanSendChannels;
 


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Фикс старого "бага", что любой видит в списке каналов телепатию, теперь там ничего не видно :)
(fix: https://github.com/SerbiaStrong-220/space-station-14/issues/1800)

**Медиа**
![image](https://github.com/user-attachments/assets/28a8ba9a-84e5-4874-8e63-9a92f5db1b7e)

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl: ReeZii
- tweak: Канал "Телепатия" больше не отображается в фильтрах чата у игроков без способности к телепатии.
