### PR TITLE
ADD: 75U For transfer and Drop Jug's

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -2,8 +2,9 @@
                 xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                 xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-                MinSize="620 670"
+                MinSize="670 670"
                 Title="{Loc 'chem-master-bound-user-interface-title'}">
+    <!-- SS220 CHANGE MIN SIZE FOR CHEM MASTER -->
     <TabContainer Name="Tabs" Margin="5 5 7 5">
         <BoxContainer Orientation="Vertical" HorizontalExpand="True" Margin="5" SeparationOverride="10">
             <!-- Input container info -->

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -124,6 +124,9 @@ namespace Content.Client.Chemistry.UI
                 ("25", ChemMasterReagentAmount.U25, StyleBase.ButtonOpenBoth),
                 ("30", ChemMasterReagentAmount.U30, StyleBase.ButtonOpenBoth),
                 ("50", ChemMasterReagentAmount.U50, StyleBase.ButtonOpenBoth),
+                // ss220 add 75u for chem master start
+                ("75", ChemMasterReagentAmount.U75, StyleBase.ButtonOpenBoth),
+                // ss220 add 75u for chem master end
                 ("100", ChemMasterReagentAmount.U100, StyleBase.ButtonOpenBoth),
                 (Loc.GetString("chem-master-window-buffer-all-amount"), ChemMasterReagentAmount.All, StyleBase.ButtonOpenLeft),
             };

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
@@ -9,15 +9,17 @@
     <BoxContainer Orientation="Horizontal">
         <BoxContainer Orientation="Vertical" MinWidth="170">
             <Label Text="{Loc 'reagent-dispenser-window-amount-to-dispense-label'}" HorizontalAlignment="Center" />
+            <!-- SS220 ADD 75U FOR DISPENSER START -->
             <ui:ButtonGrid
                 Name="AmountGrid"
                 Access="Public"
-                Columns="3"
+                Columns="2"
                 HorizontalAlignment="Center"
                 Margin="5"
-                ButtonList="1,5,10,15,20,25,30,50,100"
+                ButtonList="1,5,10,15,20,25,30,50,75,100"
                 RadioGroup="True">
             </ui:ButtonGrid>
+            <!-- SS220 ADD 75U FOR DISPENSER END -->
             <Control VerticalExpand="True" />
             <Label Name="ContainerInfoName"
                    Access="Public"

--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -168,7 +168,9 @@ namespace Content.Server.Chemistry.EntitySystems
             if (storedContainer == null)
                 return;
 
-            _handsSystem.TryPickupAnyHand(message.Actor, storedContainer);
+            //ss220 fix eject w/o empty hands start
+            _handsSystem.PickupOrDrop(message.Actor, storedContainer);
+            //ss220 fix eject w/o empty hands end
         }
 
         private void OnClearContainerSolutionMessage(Entity<ReagentDispenserComponent> reagentDispenser, ref ReagentDispenserClearContainerSolutionMessage message)

--- a/Content.Shared/Chemistry/SharedChemMaster.cs
+++ b/Content.Shared/Chemistry/SharedChemMaster.cs
@@ -111,6 +111,9 @@ namespace Content.Shared.Chemistry
         U25 = 25,
         U30 = 30,
         U50 = 50,
+        //ss220 add 75u for chemmaster start
+        U75 = 75,
+        //ss220 add 75u for chemmaster end
         U100 = 100,
         All,
     }

--- a/Content.Shared/Chemistry/SharedReagentDispenser.cs
+++ b/Content.Shared/Chemistry/SharedReagentDispenser.cs
@@ -55,6 +55,11 @@ namespace Content.Shared.Chemistry
                 case "50":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U50;
                     break;
+                //ss220 add 75u for chem master start
+                case "75":
+                    ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U75;
+                    break;
+                //ss220 add 75u for chem master end
                 case "100":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U100;
                     break;
@@ -105,6 +110,9 @@ namespace Content.Shared.Chemistry
         U25 = 25,
         U30 = 30,
         U50 = 50,
+        //ss220 add 75u for chem master start
+        U75 = 75,
+        //ss220 add 75u for chem master start
         U100 = 100,
     }
 

--- a/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
@@ -11,6 +11,10 @@
     snapCardinals: true
   - type: Storage
     openOnActivate: false
+    #ss220 fix sounds in chem master start
+    storageInsertSound: /Audio/Machines/machine_switch.ogg
+    storageOpenSound: null
+    #ss220 fix sounds in chem master end
     whitelist:
       tags:
       - ChemDispensable


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Теперь кувшины дропаются на пол, когда все руки заняты, и кликает дальше по раздатч. хим., как это было раньше.
Так же добавлен трансфер по 75 в обе хим. аппаратуры. А так же, по просьбе игрока, чутка расширил окно хим мастера, ибо иногда он открывается и некоторые кнопки стают не кликабельными.

Ещё такая хуйня, что оффы поменяли слот с кувшинами на container, и по этому сломались квик еджекты с раздатчика.
Этим займусь уже позже, но пока просто поменял звук хранилища, ибо был дефолтной сумки при вставке и открытии.

**Медиа**

![image](https://github.com/user-attachments/assets/f7463dbc-b77f-47ed-8e12-92e682a3aafe)
![image](https://github.com/user-attachments/assets/8302746f-0d66-4a87-8a5c-a7d5b612bd29)


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

no cl
