### PR TITLE
ADD: Temperature damage can now be cancelled via event

### DIFF
--- a/Content.Server/SS220/CultYogg/MiGo/MiGoSystem.cs
+++ b/Content.Server/SS220/CultYogg/MiGo/MiGoSystem.cs
@@ -19,6 +19,7 @@ using Content.Shared.Projectiles;
 using Content.Server.Projectiles;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
+using Content.Shared.SS220.Temperature;
 
 namespace Content.Server.SS220.CultYogg.MiGo;
 
@@ -45,6 +46,14 @@ public sealed partial class MiGoSystem : SharedMiGoSystem
 
         //actions
         SubscribeLocalEvent<MiGoComponent, MiGoEnslaveDoAfterEvent>(MiGoEnslaveOnDoAfter);
+
+        SubscribeLocalEvent<MiGoComponent, TemperatureDamageIsCancelEvent>(OnTemperatureDamage);
+    }
+
+    private void OnTemperatureDamage(Entity<MiGoComponent> ent, ref TemperatureDamageIsCancelEvent args)
+    {
+        if (!ent.Comp.IsPhysicalForm)
+            args.Cancel();
     }
 
     #region Astral

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Physics.Events;
 using Content.Shared.Projectiles;
+using Content.Shared.SS220.Temperature;
 
 namespace Content.Server.Temperature.Systems;
 
@@ -154,6 +155,14 @@ public sealed class TemperatureSystem : EntitySystem
 
         if (transform.MapUid == null)
             return;
+
+        //ss220
+        var ev = new TemperatureDamageIsCancelEvent();
+        RaiseLocalEvent(uid, ev);
+
+        if (ev.Cancelled)
+            return;
+        //ss220
 
         var temperatureDelta = args.GasMixture.Temperature - temperature.CurrentTemperature;
         var airHeatCapacity = _atmosphere.GetHeatCapacity(args.GasMixture, false);

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -156,13 +156,13 @@ public sealed class TemperatureSystem : EntitySystem
         if (transform.MapUid == null)
             return;
 
-        //ss220
+        //ss220 add resist for temperature start
         var ev = new TemperatureDamageIsCancelEvent();
         RaiseLocalEvent(uid, ev);
 
         if (ev.Cancelled)
             return;
-        //ss220
+        //ss220 add resist for temperature end
 
         var temperatureDelta = args.GasMixture.Temperature - temperature.CurrentTemperature;
         var airHeatCapacity = _atmosphere.GetHeatCapacity(args.GasMixture, false);

--- a/Content.Shared/SS220/Temperature/TemperatureEvents.cs
+++ b/Content.Shared/SS220/Temperature/TemperatureEvents.cs
@@ -1,0 +1,8 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.SS220.Temperature;
+
+[Serializable, NetSerializable]
+public sealed partial class TemperatureDamageIsCancelEvent : CancellableEntityEventArgs
+{
+}


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Добавил ивент `TemperatureDamageIsCancelEvent` , который позволяет отменить теплопередачу от внешней среды. В следствии чего, урона не будет.

Теперь МиГо не будет получать дамаг от температуры в астрале.

**Медиа**

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- fix: МиГо теперь не получает урон от температуры пока находится в астральном мире
