### PR TITLE
ADD: Examine nuke for remaining time to explode

### DIFF
--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -657,6 +657,11 @@ public sealed class NukeSystem : EntitySystem
             args.PushMarkup(Loc.GetString("examinable-anchored"));
         else
             args.PushMarkup(Loc.GetString("examinable-unanchored"));
+
+        //ss220 add examined time for nuke start
+        if (component.Status == NukeStatus.ARMED)
+            args.PushMarkup(Loc.GetString("nuke-comp-time-remaining", ("time", (int)component.RemainingTime)));
+        //ss220 add examine time for nuke end
     }
 }
 

--- a/Resources/Locale/ru-RU/ss220/nuke/nuke.ftl
+++ b/Resources/Locale/ru-RU/ss220/nuke/nuke.ftl
@@ -1,0 +1,1 @@
+nuke-comp-time-remaining = До взрыва осталось { $time } секунд.


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Для бомбы добавлено время до взрыва при осмотре.

**Медиа**

![image](https://github.com/user-attachments/assets/60c755ea-ab65-457d-a84c-6983f5b2de8c)


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl:
- add: Ядерная боеголовка теперь показывает время до взрыва
