### PR TITLE
FIX: Quartermaster mech clothing

### DIFF
--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -147,6 +147,12 @@ public abstract class SharedMechSystem : EntitySystem
 
     private void OnGetAdditionalAccess(EntityUid uid, MechComponent component, ref GetAdditionalAccessEvent args)
     {
+        //SS220-MechClothingInHandsFix-start
+        // If it's not a proper mech, then skip additional access gathering
+        if (!HasComp<MechRobotComponent>(uid))
+            return;
+        //SS220-MechClothingInHandsFix-end
+
         var pilot = component.PilotSlot.ContainedEntity;
         if (pilot == null)
             return;


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->
Добавлена проверка на компонент MechRobotComponent в системе SharedMechSystem в методе OnGetAdditionalAccess.

### Проблема:
Если взять в **руки** экзоскелет квартирмейстера и попытаться с ним открыть шлюзы, желаемого эффекта не будет.
![screenshot](https://github.com/user-attachments/assets/e6c12393-2bcb-4a66-9d6c-57d88d6817ab)

### Визуальная проблема: 
Дверь не открывается, когда должна открываться.
### Техническая проблема: 
Начинается дикий спам исключениями NullReferense как из пулемета.

### Суть проблемы: 
Суть лежит в том что при попытке открыть шлюз идет проверка на доступы к этому шлюзу, включая проверку предметов в руках, в которых у нас лежит экзоскелет, который в свою очередь квалифицируется как Мех, у которых уже в свою очередь есть дополнительная проверка доступов у пилотов данного Меха. **Однако**, хоть наш экзоскелет и считается Мехом, пилота у него нету. Как результат: пилота мы не находим, строчим исключения в консоль, дверь не открываем.

### Решение: 
При проверке на дополнительные доступы у мехов, проверяем полноценный ли это мех.

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт.

Ссылки на медиа (изображения/видео) будут добавлены в список изменений на дискорд сервере (не более 10 ссылок каждого вида и 8 МБ суммарного веса (для каждого вида)).
Всё что записано между тегами "CLIgnore" будет игнорироваться при отправке списка изменений.-->

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру и на дискорд сервер, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->
:cl: 
- fix: Исправлена проблема с открытием шлюзов, когда в руках находится экзоскелет квартирмейстера


