### PR TITLE
ADD: Syndie UI requires access

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -23,6 +23,7 @@ using Robust.Shared.Utility;
 using Content.Shared.UserInterface;
 using Robust.Shared.Prototypes;
 using Content.Server.SS220.CruiseControl;
+using Content.Shared.Access.Systems;
 
 namespace Content.Server.Shuttles.Systems;
 
@@ -58,7 +59,11 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
         SubscribeLocalEvent<ShuttleConsoleComponent, ComponentShutdown>(OnConsoleShutdown);
         SubscribeLocalEvent<ShuttleConsoleComponent, PowerChangedEvent>(OnConsolePowerChange);
         SubscribeLocalEvent<ShuttleConsoleComponent, AnchorStateChangedEvent>(OnConsoleAnchorChange);
-        SubscribeLocalEvent<ShuttleConsoleComponent, ActivatableUIOpenAttemptEvent>(OnConsoleUIOpenAttempt);
+
+        // ss220 add ui requires access start (#282)
+        SubscribeLocalEvent<ShuttleConsoleComponent, ActivatableUIOpenAttemptEvent>(OnConsoleUIOpenAttempt, after: [typeof(ActivatableUIRequiresAccessSystem)]);
+        // ss220 add ui requires access end
+
         Subs.BuiEvents<ShuttleConsoleComponent>(ShuttleConsoleUiKey.Key, subs =>
         {
             subs.Event<ShuttleConsoleFTLBeaconMessage>(OnBeaconFTLMessage);
@@ -154,6 +159,11 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
     private void OnConsoleUIOpenAttempt(EntityUid uid, ShuttleConsoleComponent component,
         ActivatableUIOpenAttemptEvent args)
     {
+        // ss220 add ui requires access start (#282)
+        if (args.Cancelled)
+            return;
+        // ss220 add ui requires access end
+
         if (!TryPilot(args.User, uid))
             args.Cancel();
     }

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -208,6 +208,11 @@
     color: "#c94242"
   - type: Computer
     board: SyndicateShuttleConsoleCircuitboard
+  # ss220 add ui requires access start (#282)
+  - type: ActivatableUIRequiresAccess
+  - type: AccessReader
+    access: [["SyndicateAgent"], ["NuclearOperative"]]
+  # ss220 add ui requires access end
 
 - type: entity
   parent: BaseComputerShuttle
@@ -732,8 +737,11 @@
       state: syndie_key
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       state: generic_panel_open
+  # ss220 add ui requires access start (#282)
+  - type: ActivatableUIRequiresAccess
   - type: AccessReader
-    access: [[ "NuclearOperative" ]]
+    access: [["SyndicateAgent"], ["NuclearOperative"]]
+  # ss220 add ui requires access end
   - type: CommunicationsConsole
     title: comms-console-announcement-title-nukie
     color: "#ff0000"


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Консоли шаттла управления и консоль связи синдиката теперь доступны только по доступу ЯО или синдиката 
(fix: https://github.com/SerbiaStrong-220/DevTeam220/issues/282)

**Медиа**

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: ReeZii
- add: Консоль управления шаттлом Синдиката и консоль связи Синдиката теперь требуют соответствующие доступы на ID-карте для активации.
