### PR TITLE
TWEAK: Delay ion storm announcement until event ends

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -684,18 +684,21 @@
   components:
   - type: StationEvent
   # SS220 MoreAnonces (sound and alert upgrades) bgn
-    startAnnouncementColor: "#18abf5"
-    #ss220 disable ion storm announcement start
-    #startAnnouncement: station-event-ion-storm-start-announcement
-    #startAudio:
-      #path: /Audio/SS220/Announcements/i-storm1.ogg
-      #params:
-        #volume: -4
-    #ss220 disable ion storm announcement end
+    #ss220 tweak ion storm start
+    endAnnouncementColor: "#18abf5"
+    endAnnouncement: station-event-ion-storm-start-announcement
+    endAudio:
+      path: /Audio/SS220/Announcements/i-storm1.ogg
+      params:
+        volume: -4
+    #ss220 tweak ion storm start
   # SS220 MoreAnonces (sound and alert upgrades) end
     weight: 8
     reoccurrenceDelay: 20
-    duration: 1
+    #ss220 tweak ion storm start
+    duration: 900
+    maxDuration: 1200
+    #ss220 tweak ion storm end
   - type: IonStormRule
 
 - type: entity

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -685,11 +685,13 @@
   - type: StationEvent
   # SS220 MoreAnonces (sound and alert upgrades) bgn
     startAnnouncementColor: "#18abf5"
-    startAnnouncement: station-event-ion-storm-start-announcement
-    startAudio:
-      path: /Audio/SS220/Announcements/i-storm1.ogg
-      params:
-        volume: -4
+    #ss220 disable ion storm announcement start
+    #startAnnouncement: station-event-ion-storm-start-announcement
+    #startAudio:
+      #path: /Audio/SS220/Announcements/i-storm1.ogg
+      #params:
+        #volume: -4
+    #ss220 disable ion storm announcement end
   # SS220 MoreAnonces (sound and alert upgrades) end
     weight: 8
     reoccurrenceDelay: 20


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Теперь оповещение об ионном шторме срабатывает после конца самого ивента, а это в пределах 15-20 минут 

(fix: https://github.com/SerbiaStrong-220/DevTeam220/issues/388)

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl: ReeZii
- tweak: Оповещение об ионном шторме теперь срабатывает после завершения самого ивента, с задержкой 15–20 минут
