### PR TITLE
STAI Power Grid control

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -130,6 +130,7 @@
   - type: Battery
     maxCharge: 8000000
     startingCharge: 8000000
+  - type: StationAiWhitelist #SS220 AI power control
 
 - type: entity
   parent: SMESBasic

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -83,6 +83,7 @@
       shader: unshaded
     - state: full
       shader: unshaded
+  - type: StationAiWhitelist #SS220 AI power control
   - type: Battery
     maxCharge: 2500000
     startingCharge: 0


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Данный ПР расширяет возможности СЕИИ к контролю питания станции посредством добавления вайтлиста управления на подстанции и смесы. (Не обращайте внимания на название ветки. Изначально должен был быть пр на контроль шаттлом, но там в консоле насрано)


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.


**Изменения**

:cl:
- add: Станционному ИИ добавлена возможность управления СМЭСами и подстанциями
