### PR TITLE
ADD: Editable title for War Declarator

### DIFF
--- a/Content.Server/NukeOps/WarDeclaratorComponent.cs
+++ b/Content.Server/NukeOps/WarDeclaratorComponent.cs
@@ -39,12 +39,14 @@ public sealed partial class WarDeclaratorComponent : Component
     [DataField]
     public SoundSpecifier Sound = new SoundPathSpecifier("/Audio/Announcements/war.ogg");
 
+    // ss220 add editable title for war declarator start
     /// <summary>
     /// Fluent ID for the declaration sender title
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField]
-    public LocId SenderTitle = "comms-console-announcement-title-nukie";
+    public string SenderTitle = "comms-console-announcement-title-nukie";
+    // ss220 add editable title for war declarator end
 
     /// <summary>
     /// Time allowed for declaration of war

--- a/Content.Server/NukeOps/WarDeclaratorSystem.cs
+++ b/Content.Server/NukeOps/WarDeclaratorSystem.cs
@@ -70,7 +70,11 @@ public sealed class WarDeclaratorSystem : EntitySystem
 
         if (ev.Status == WarConditionStatus.WarReady)
         {
-            var title = Loc.GetString(ent.Comp.SenderTitle);
+            // ss220 add editable title for war declarator start
+            Loc.TryGetString(ent.Comp.SenderTitle, out var title);
+            title ??= ent.Comp.SenderTitle;
+            // ss220 add editable title for war declarator end
+
             _chat.DispatchGlobalAnnouncement(ent.Comp.Message, title, true, ent.Comp.Sound, ent.Comp.Color);
             _adminLogger.Add(LogType.Chat, LogImpact.Low, $"{ToPrettyString(args.Actor):player} has declared war with this text: {ent.Comp.Message}");
         }

--- a/Content.Server/NukeOps/WarDeclaratorSystem.cs
+++ b/Content.Server/NukeOps/WarDeclaratorSystem.cs
@@ -70,11 +70,7 @@ public sealed class WarDeclaratorSystem : EntitySystem
 
         if (ev.Status == WarConditionStatus.WarReady)
         {
-            // ss220 add editable title for war declarator start
-            Loc.TryGetString(ent.Comp.SenderTitle, out var title);
-            title ??= ent.Comp.SenderTitle;
-            // ss220 add editable title for war declarator end
-
+            var title = Loc.GetString(ent.Comp.SenderTitle);
             _chat.DispatchGlobalAnnouncement(ent.Comp.Message, title, true, ent.Comp.Sound, ent.Comp.Color);
             _adminLogger.Add(LogType.Chat, LogImpact.Low, $"{ToPrettyString(args.Actor):player} has declared war with this text: {ent.Comp.Message}");
         }


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
В вв декларатора теперь можно выставить кастомную строчку того, кто объявляет войну. 

(close: https://github.com/SerbiaStrong-220/DevTeam220/issues/414) 

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

no cl
