### PR TITLE
Energy Katana Toy in storage

### DIFF
--- a/Resources/Prototypes/SS220/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Fun/toys.yml
@@ -367,7 +367,11 @@
       types:
         Slash: 0.01
   - type: Item
-    sprite: Objects/Weapons/Melee/energykatana.rsi
+    storedSprite:
+      state: storage
+      sprite: Objects/Weapons/Melee/energykatana_storage_64x.rsi #Done in 64x64 because it looks way too puny in 32x32
+    shape:
+    - 0,0,0,3
   - type: Clothing
     sprite: Objects/Weapons/Melee/energykatana.rsi
     slots:

--- a/Resources/Prototypes/SS220/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Fun/toys.yml
@@ -366,12 +366,14 @@
     damage:
       types:
         Slash: 0.01
+ #SS220 the beginning of changes
   - type: Item
     storedSprite:
       state: storage
-      sprite: Objects/Weapons/Melee/energykatana_storage_64x.rsi #Done in 64x64 because it looks way too puny in 32x32
+      sprite: Objects/Weapons/Melee/energykatana_storage_64x.rsi 
     shape:
     - 0,0,0,3
+#SS220 the end of changes    
   - type: Clothing
     sprite: Objects/Weapons/Melee/energykatana.rsi
     slots:


### PR DESCRIPTION
## Описание PR
Теперь игрушечная катана правильно отображается в хранилищах
**Медиа**
<img width="672" height="349" alt="image" src="https://github.com/user-attachments/assets/b48077d5-da69-4df1-a9ed-f40335ba139a" />
**Проверки**
<!--/CLIgnore-->
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl: inksansik
- fix: Исправленно отображение игрушечной катаны в хранилищах