### PR TITLE
Fix midround events?

### DIFF
--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -96,8 +96,8 @@
   - type: StationEvent
     weight: 4
     duration: 120
-    minimumPlayers: 0
-    earliestStart: 0
+    minimumPlayers: 40
+    earliestStart: 30
   - type: CargoGiftsRule
     description: cargo-gift-vending
     dest: cargo-gift-dest-supp

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -2,7 +2,9 @@
 
 - type: entityTable
   id: CargoGiftsTable
-  table: !type:GroupSelector # ~~we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp~~ But we arent doing that shit yet, it picks a random one StationEventComp be damned.
+  # SS220 Midround events fix begin
+  table: !type:AllSelector # ~~we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp~~ But we arent doing that shit yet, it picks a random one StationEventComp be damned.
+  # SS220 Midround events fix end
     children:
     - id: GiftsEngineering
     - id: GiftsFireProtection
@@ -94,8 +96,8 @@
   - type: StationEvent
     weight: 4
     duration: 120
-    minimumPlayers: 40
-    earliestStart: 30
+    minimumPlayers: 0
+    earliestStart: 0
   - type: CargoGiftsRule
     description: cargo-gift-vending
     dest: cargo-gift-dest-supp


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->
Заметил что неверно выбираются ивенты из категории `CargoGiftsTable`. Вместо выборки всех ивентов и проверки возможности их запуска - выбирался только 1 и только он и проверялся на возможность запуска. 

С остальными категориями выборка производится верно.

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
no cl