### PR TITLE
FIX: Vox Thermoregulation

### DIFF
--- a/Resources/Prototypes/SS220/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/SS220/Entities/Mobs/Species/base.yml
@@ -49,7 +49,7 @@
     sweatHeatRegulation: 2000
     shiveringHeatRegulation: 2000
     normalBodyTemperature: 310.15
-    thermalRegulationTemperatureThreshold: 25
+    thermalRegulationTemperatureThreshold: 2
   - type: Butcherable
     butcheringType: Spike # TODO human.
     spawned:


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
После последнего апстрима поменяли терморегуляцию у мобов, а у воксов так и осталась 25 вместо 2 нужных.
(close: https://github.com/SerbiaStrong-220/space-station-14/issues/3197)

Сам пр от оффов: https://github.com/space-wizards/space-station-14/pull/36062

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
no cl
