### PR TITLE
Фикс детектива в неопознанных трупах

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Corpses/corpses.yml
+++ b/Resources/Prototypes/Entities/Mobs/Corpses/corpses.yml
@@ -18,7 +18,6 @@
     - PassengerStandartGear
     - ReporterStandartGear #SS220 new roles corpses
     - ZookeeperStandartGear #SS220 new roles corpses
-    - DetectiveStandartGear #SS220 Detective in service
     #SS220 corpses equipment fix end
 
 - type: entity
@@ -85,7 +84,7 @@
     - SecurityCadetStandartGear
     - SecurityPilotStandartGear #SS220 new roles corpses
     - SecurityOfficerStandartGear
-    # - DetectiveStandartGear
+    - DetectiveStandartGear
     - WardenStandartGear
     #SS220 corpses equipment fix end
 


### PR DESCRIPTION
## Описание PR
В спавнах неопознанных трупов, детектив числился как сервис. Изменено на СБ. Теперь детектив спавнится как неопознанный труп у спавна СБ.

**Медиа**
Не требует


**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.


**Изменения**
:cl: Ordi
- fix: Перенос детектива из сервиса в СБ в спавнерах неопознанных трупов.