### PR TITLE
ADD: Anti FoV changer

### DIFF
--- a/Content.Client/SS220/AntiCheat/FOV/AntiCheatFovDetectionSystem.cs
+++ b/Content.Client/SS220/AntiCheat/FOV/AntiCheatFovDetectionSystem.cs
@@ -1,0 +1,41 @@
+using Content.Shared.SS220.AntiCheat.FOV;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Client.SS220.AntiCheat.FOV;
+
+public sealed class AntiCheatFovDetectionSystem : EntitySystem
+{
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+
+    private readonly TimeSpan _timeForUpdate = TimeSpan.FromSeconds(5);
+    private TimeSpan _lastSent = TimeSpan.Zero;
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_player.LocalEntity == null)
+            return;
+
+        var now = _gameTiming.CurTime;
+        if (now - _lastSent < _timeForUpdate)
+            return;
+
+        _lastSent = now;
+
+        if (!TryComp<EyeComponent>(_player.LocalEntity, out var eye))
+            return;
+
+        var compDrawFov = eye.DrawFov;
+        var compDrawLight = eye.DrawLight;
+
+        var eyeDrawFov = eye.Eye.DrawFov;
+        var eyeDrawLight = eye.Eye.DrawLight;
+
+        var ev = new FovEvent(compDrawFov, compDrawLight, eyeDrawFov, eyeDrawLight);
+        RaiseNetworkEvent(ev);
+    }
+}

--- a/Content.Server/SS220/AntiCheat/FOV/AntiCheatFovDetectionSystem.cs
+++ b/Content.Server/SS220/AntiCheat/FOV/AntiCheatFovDetectionSystem.cs
@@ -1,0 +1,60 @@
+using Content.Server.Administration.Logs;
+using Content.Server.Administration.Managers;
+using Content.Shared.Database;
+using Content.Shared.Ghost;
+using Content.Shared.SS220.AntiCheat.FOV;
+using Content.Shared.SS220.CultYogg.MiGo;
+
+namespace Content.Server.SS220.AntiCheat.FOV;
+
+public sealed class AntiCheatFovDetectionSystem : EntitySystem
+{
+    [Dependency] private readonly IAdminLogManager _adminLog = default!;
+    [Dependency] private readonly IAdminManager _adminManager = default!;
+    //[Dependency] private readonly IServerNetManager _serverNet = default!;
+    // if you need to disconnect cheater
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeNetworkEvent<FovEvent>(OnFovDetectionEvent);
+    }
+
+    private void OnFovDetectionEvent(FovEvent ev, EntitySessionEventArgs args)
+    {
+        var player = args.SenderSession.AttachedEntity;
+        if (player == null)
+            return;
+
+        if (HasComp<GhostComponent>(player))
+            return;
+
+        if (_adminManager.IsAdmin(player.Value))
+            return;
+
+        if (!TryComp<EyeComponent>(player, out var eye))
+            return;
+
+        if (TryComp<MiGoComponent>(player, out var miGo) && !miGo.IsPhysicalForm)
+            return;
+
+        var serverDrawFov = eye.DrawFov;
+        var serverDrawLight = eye.DrawLight;
+
+        var mismatchFov = ev.FovFromEye != serverDrawFov || ev.FovFromComp != serverDrawFov;
+        var mismatchLight = ev.LightFromEye != serverDrawLight || ev.LightFromComp != serverDrawLight;
+
+        if (!mismatchFov && !mismatchLight)
+            return;
+
+        _adminLog.Add(
+            LogType.Action,
+            LogImpact.Extreme,
+            $"User {ToPrettyString(player):player} triggered {nameof(AntiCheatFovDetectionSystem)})");
+
+        //_serverNet.DisconnectChannel(args.SenderSession.Channel, "Visual cheat detected");
+        // if you need to disconnect cheater
+    }
+
+}

--- a/Content.Shared/SS220/AntiCheat/FOV/FovEvents.cs
+++ b/Content.Shared/SS220/AntiCheat/FOV/FovEvents.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.SS220.AntiCheat.FOV;
+
+[Serializable, NetSerializable]
+public sealed partial class FovEvent(
+    bool fovFromComp,
+    bool lightFromComp,
+    bool fovFromEye,
+    bool lightFromEye) : EntityEventArgs
+{
+    public bool FovFromComp = fovFromComp;
+    public bool LightFromComp = lightFromComp;
+
+    public bool FovFromEye = fovFromEye;
+    public bool LightFromEye = lightFromEye;
+}


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Сравнивает клиентские значения FoV и Light класса Eye, и поля компонента с значениями на сервере.
Клиентские значения очень легко меняются с помощью одной популярной програмки за 2 минуты. Я не беру в расчет читы, которые лежат на гитхабе, хотя данный фикс их скорее всего тоже затронет, ибо меняют они значения через Clyde.

**Медиа**

https://github.com/user-attachments/assets/fb3c72c9-6b8d-42f3-8919-4b985ebba4f9


<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

no cl no fun
