### PR TITLE
Добавление командной частоты АВД

### DIFF
--- a/Resources/Locale/ru-RU/ss220/clothing/Ears/headset.ftl
+++ b/Resources/Locale/ru-RU/ss220/clothing/Ears/headset.ftl
@@ -8,6 +8,9 @@ ent-ClothingHeadsetAltMagistrate = полноразмерная гарнитур
 ent-ClothingHeadsetMagistrate = гарнитура магистрата
     .desc = Её используют гиганты правосудия.
 
+ent-ClothingHeadsetAltIAA = полноразмерная гарнитура АВД
+    .desc = Гарнитура агента внутренних дел, чтобы услышать последние слова капитана.
+
 ent-ClothingHeadsetAltCaptain = полноразмерная гарнитура капитана
     .desc = Модифицированный модульный интерком, надеваемый на голову. Принимает ключи шифрования.
 ent-ClothingHeadsetCaptain = гарнитура капитана

--- a/Resources/Locale/ru-RU/ss220/loadout-groups/lawyer.ftl
+++ b/Resources/Locale/ru-RU/ss220/loadout-groups/lawyer.ftl
@@ -1,1 +1,2 @@
 loadout-group-lawyer-outerclothing = Адвокат, верхняя одежда
+loadout-group-lawyer-headset = Адвокат, гарнитура

--- a/Resources/Prototypes/Corvax/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/Ears/headsets.yml
@@ -7,7 +7,13 @@
     - type: ContainerFill
       containers:
         key_slots:
-        - EncryptionKeyIAA
-        - EncryptionKeyLaw #SS220-Law Department
+        # SS220 add-iaa-command-key begin
+        - EncryptionKeyLaw
+        - EncryptionKeySecurity
+        - EncryptionKeyCommon
+        - EncryptionKeyCommand
     - type: Sprite
-      sprite: Clothing/Ears/Headsets/servicesecurity.rsi
+      sprite: SS220/Clothing/Ears/Headsets/law.rsi
+    - type: Clothing
+      sprite: SS220/Clothing/Ears/Headsets/law.rsi
+        # SS220 add-iaa-command-key end

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -117,7 +117,7 @@
   id: JobLawyer
   groups:
   - IAAGlasses #SS220-Two Floppa Iteration
-  - IAAHeadset #SS220-Law Department
+  - LawyerHeadset #SS220-Law Department & SS220 add-iaa-command-key
   - GroupTankHarness
   - LawyerNeck
   - LawyerJumpsuit

--- a/Resources/Prototypes/SS220/Entities/Clothing/Ears/headset.yml
+++ b/Resources/Prototypes/SS220/Entities/Clothing/Ears/headset.yml
@@ -61,6 +61,20 @@
       - EncryptionKeyCommand
 
 - type: entity
+  parent: ClothingHeadsetAltLaw
+  id: ClothingHeadsetAltIAA
+  name: full-size headset of the iaa
+  description: A headset for internal affairs agent to hear the captain's last words.
+  components:
+    - type: ContainerFill
+      containers:
+        key_slots:
+        - EncryptionKeyLaw
+        - EncryptionKeySecurity
+        - EncryptionKeyCommon
+        - EncryptionKeyCommand
+
+- type: entity
   parent: ClothingHeadsetAlt
   id: ClothingHeadsetAltCaptain
   name: full-size headset of the Captain

--- a/Resources/Prototypes/SS220/Loadouts/Jobs/InternalAffairs/iaa.yml
+++ b/Resources/Prototypes/SS220/Loadouts/Jobs/InternalAffairs/iaa.yml
@@ -106,3 +106,13 @@
   id: LawHeadsetAlt
   equipment:
     ears: ClothingHeadsetAltLaw
+
+- type: loadout
+  id: IAAHeadset
+  equipment:
+    ears: ClothingHeadsetIAA
+
+- type: loadout
+  id: IAAHeadsetAlt
+  equipment:
+    ears: ClothingHeadsetAltIAA

--- a/Resources/Prototypes/SS220/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/SS220/Loadouts/loadout_groups.yml
@@ -133,8 +133,8 @@
   name: loadout-group-iaa-headset
   minLimit: 1
   loadouts:
-  - LawHeadset
-  - LawHeadsetAlt
+  - IAAHeadset
+  - IAAHeadsetAlt
   # Агент Внутренних Дел (Конец)
 
   # Адвокат (Начало)
@@ -144,6 +144,14 @@
   minLimit: 0
   loadouts:
   - OuterClothingJujutsuShlepa
+
+- type: loadoutGroup
+  id: LawyerHeadset
+  name: loadout-group-lawyer-headset
+  minLimit: 1
+  loadouts:
+  - LawHeadset
+  - LawHeadsetAlt
   # Адвокат (Конец)
 
   # Офицер "Синий Щит" (Начало)


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
**Добавление командной частоты АВД. Зачем?**

Сейчас отсутствие командной частоты у АВД — лишь рудимент старых решений. На практике у АВД есть доступ к командованию и возможность распоряжаться мостиком. У него есть ручка ЦК, главы регулярно обращаются к нему за помощью в различных ситуациях. АВД может поставить точку в споре о СРП по командной частоте и решать множество других вопросов. Фактически, в каждом раунде эта частота у одного из АВД уже есть — магистрат выдаёт её даже без запроса.

Наш АВД — это синтез ролей НТР и АВД с 13-й станции. На 13-й станции АВД занимается исключительно вопросами экипажа, оставляя командные дела НТР. У нас же АВД совмещает обе функции: он работает и с членами экипажа, и с командованием.

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl: Kemran
- add: Добавлена гарнитура АВД с командной частотой.