### PR TITLE
Decreasing minplayers for 2 times by normal limit for mid-highpop maps

### DIFF
--- a/Resources/Prototypes/SS220/Maps/astro.yml
+++ b/Resources/Prototypes/SS220/Maps/astro.yml
@@ -4,7 +4,7 @@
   id: Astro
   mapName: 'JSS Astro'
   mapPath: /Maps/SS220/astro.yml
-  minPlayers: 30
+  minPlayers: 15 ## decreased for 2 times by normal limit
   stations:
     Astro:
       stationProto: AstroNanotrasenStation

--- a/Resources/Prototypes/SS220/Maps/axioma.yml
+++ b/Resources/Prototypes/SS220/Maps/axioma.yml
@@ -4,7 +4,7 @@
   id: Axioma
   mapName: 'NSS Axioma'
   mapPath: /Maps/SS220/axioma.yml
-  minPlayers: 45
+  minPlayers: 25 ## normal limit: 45
   stations:
     Axioma:
       stationProto: AxiomaNanotrasenStation

--- a/Resources/Prototypes/SS220/Maps/eclipse.yml
+++ b/Resources/Prototypes/SS220/Maps/eclipse.yml
@@ -4,7 +4,7 @@
   id: Eclipse
   mapName: 'NSS Eclipse'
   mapPath: /Maps/SS220/eclipse.yml
-  minPlayers: 40
+  minPlayers: 20 # decreased for 2 times by normal limit
   stations:
     Eclipse:
       stationProto: EclipseNanotrasenStation


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

Снижаем количество игроков необходимое для игры на картах с расчётом на средний или высокий онлайн, в связи с тенденциями падения онлайна из-за множества наложившихся проблем.

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl:
- tweak: Уменьшено минимальное необходимое количество игроков для карт Axioma, Astro, Eclipse в 2 раза.
