### PR TITLE
Revert "Food sequence fix"

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/FoodSequenceSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/FoodSequenceSystem.cs
@@ -107,7 +107,7 @@ public sealed class FoodSequenceSystem : SharedFoodSequenceSystem
     private bool TryAddFoodElement(Entity<FoodSequenceStartPointComponent> start, Entity<FoodSequenceElementComponent> element, EntityUid? user = null)
     {
         // we can't add a live mouse to a burger.
-        if (!TryComp<EdibleComponent>(element, out var elementFood)) //SS220-food-sequence-fix
+        if (!TryComp<FoodComponent>(element, out var elementFood))
             return false;
         if (elementFood.RequireDead && _mobState.IsAlive(element))
             return false;


### PR DESCRIPTION
Reverts SerbiaStrong-220/space-station-14#3306

Проблема оказалась сложнее, чем на первый взгляд.
До поры до времени лучше уж оно не будет работать, чем работать, но с ошибками.

В чем суть - при сборке бургера, система пытается удалить энтити игредиентов, из-за чего выдается ошибка:

>  Predicting the queued deletion of a networked entity:

В результате происходит дубликат бургера:

<img width="776" height="224" alt="image" src="https://github.com/user-attachments/assets/088a8b14-6bab-4acf-bc83-42567170ce8c" />

Что я нашел по поводу этого у оффов:

`FoodComponent` и `DrinkComponent` будут вырезать подчистую, так как их заменил `EdibleComponent`  -> https://github.com/space-wizards/space-station-14/issues/40046

Хотфикс, который все еще не исправляет выдачу ошибки (проверил у себя) -> https://github.com/space-wizards/space-station-14/pull/39773