### PR TITLE
ADD: Block heavy attack and shooting while User is Down

### DIFF
--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -212,7 +212,10 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         // ss220 add block heavy attack and shooting while user is down start
         if (_standing.IsDown(user))
+        {
+            PopupSystem.PopupPredictedCursor(Loc.GetString("lying-down-block-attack"), user);
             return;
+        }
         // ss220 add block heavy attack and shooting while user is down end
 
         if (!TryGetWeapon(user, out var weaponUid, out var weapon) ||

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -248,7 +248,10 @@ public abstract partial class SharedGunSystem : EntitySystem
 
         // ss220 add block heavy attack and shooting while user is down start
         if (_standing.IsDown(user))
+        {
+            PopupSystem.PopupPredictedCursor(Loc.GetString("lying-down-block-shooting"), user);
             return;
+        }
         // ss220 add block heavy attack and shooting while user is down end
 
         var toCoordinates = gun.ShootCoordinates;

--- a/Resources/Locale/ru-RU/ss220/actions/lying-down.ftl
+++ b/Resources/Locale/ru-RU/ss220/actions/lying-down.ftl
@@ -1,1 +1,4 @@
 ent-ActionStandUp = встать
+
+lying-down-block-attack = Запрещено атаковать широкой атакой в позиции лёжа
+lying-down-block-shooting = Запрещено стрелять в позиции лёжа


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Теперь нельзя атаковать широкой атакой (ПКМ) или стрелять, если ты лежишь.
Так же вылазят Поп-апки.
(fix: https://github.com/SerbiaStrong-220/DevTeam220/issues/477)

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl: ReeZii
- add: Теперь нельзя атаковать широкой атакой (ПКМ), когда персонаж находится в положении лёжа
- add: Теперь нельзя стрелять, когда персонаж находится в положении лёжа.
