### PR TITLE
ADD: No insta trigger from Door Signal

### DIFF
--- a/Content.Server/DeviceLinking/Components/DoorSignalControlComponent.cs
+++ b/Content.Server/DeviceLinking/Components/DoorSignalControlComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.DeviceLinking;
+using Robust.Shared.Prototypes; // ss220 add open/close ports to door
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.DeviceLinking.Components
@@ -20,5 +21,13 @@ namespace Content.Server.DeviceLinking.Components
 
         [DataField("onOpenPort", customTypeSerializer: typeof(PrototypeIdSerializer<SourcePortPrototype>))]
         public string OutOpen = "DoorStatus";
+
+        // ss220 add open/close ports to door start
+        [DataField]
+        public ProtoId<SourcePortPrototype> OpenedPortOut = "DoorOpened";
+
+        [DataField]
+        public ProtoId<SourcePortPrototype> ClosedPortOut = "DoorClosed";
+        // ss220 add open/close ports to door end
     }
 }

--- a/Content.Server/DeviceLinking/Systems/DoorSignalControlSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/DoorSignalControlSystem.cs
@@ -94,19 +94,22 @@ namespace Content.Server.DeviceLinking.Systems
             if (TryComp<ApcPowerReceiverComponent>(uid, out var receiverComp) && !receiverComp.Powered)
                 return;
 
+            // ss220 add open/close ports to door start
             if (args.State == DoorState.Closed)
             {
                 // only ever say the door is closed when it is completely airtight
                 _signalSystem.SendSignal(uid, door.OutOpen, false);
+                _signalSystem.SendSignal(uid, door.ClosedPortOut, true);
             }
-            else if (args.State == DoorState.Open
-                     || args.State == DoorState.Opening
-                     || args.State == DoorState.Closing
-                     || args.State == DoorState.Emagging)
+            else if (args.State is DoorState.Open or DoorState.Opening or DoorState.Closing or DoorState.Emagging)
             {
                 // say the door is open whenever it would be letting air pass
                 _signalSystem.SendSignal(uid, door.OutOpen, true);
+
+                if (args.State is DoorState.Open)
+                    _signalSystem.SendSignal(uid, door.OpenedPortOut, true);
             }
+            // ss220 add open/close ports to door end
         }
     }
 }

--- a/Content.Shared/DeviceLinking/DeviceLinkSinkComponent.cs
+++ b/Content.Shared/DeviceLinking/DeviceLinkSinkComponent.cs
@@ -46,4 +46,9 @@ public sealed partial class DeviceLinkSinkComponent : Component
     /// </summary>
     [DataField]
     public int InvokeLimit = 10;
+
+    // ss220 add open/close ports to door start
+    [DataField]
+    public bool TriggerOnLink = true;
+    // ss220 add open/close ports to door end
 }

--- a/Content.Shared/DeviceLinking/SharedDeviceLinkSystem.cs
+++ b/Content.Shared/DeviceLinking/SharedDeviceLinkSystem.cs
@@ -442,7 +442,11 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
             linkedPorts.Add((source, sink));
             sinkComponent.LinkedSources.Add(sourceUid);
 
-            SendNewLinkEvent(userId, sourceUid, source, sinkUid, sink);
+            // ss220 add open/close ports to door start
+            if (sinkComponent.TriggerOnLink)
+                SendNewLinkEvent(userId, sourceUid, source, sinkUid, sink);
+            // ss220 add open/close ports to door end
+
             CreateLinkPopup(userId, sourceUid, source, sinkUid, sink, false);
         }
 

--- a/Resources/Locale/ru-RU/ss220/machine-linking/transmitter_ports.ftl
+++ b/Resources/Locale/ru-RU/ss220/machine-linking/transmitter_ports.ftl
@@ -1,0 +1,5 @@
+signal-port-name-doorstatus-opened = Открытый шлюз
+signal-port-description-doorstatus-opened = Этот порт задействуется когда шлюз полностью открыт.
+
+signal-port-name-doorstatus-closed = Закрытый шлюз
+signal-port-description-doorstatus-closed = Этот порт задействуется когда шлюз полностью закрыт.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -75,6 +75,7 @@
   - type: DeviceLinkSink
     ports:
     - Trigger
+    triggerOnLink: false # ss220 add open/close ports to door
   - type: Explosive # Powerful explosion in a very small radius. Doesn't break underplating.
     explosionType: DemolitionCharge
     totalIntensity: 60

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -117,6 +117,10 @@
   - type: DeviceLinkSource
     ports:
       - DoorStatus
+      # ss220 add open/close ports to door start
+      - DoorOpened
+      - DoorClosed
+      # ss220 add open/close ports to door end
     lastSignals:
       DoorStatus: false
   - type: SoundOnOverload

--- a/Resources/Prototypes/SS220/DeviceLinking/source_ports.yml
+++ b/Resources/Prototypes/SS220/DeviceLinking/source_ports.yml
@@ -1,0 +1,9 @@
+- type: sourcePort
+  id: DoorOpened
+  name: signal-port-name-doorstatus-opened
+  description: signal-port-description-doorstatus-opened
+
+- type: sourcePort
+  id: DoorClosed
+  name: signal-port-name-doorstatus-closed
+  description: signal-port-description-doorstatus-closed


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Теперь,  если в Sink-er указать triggerOnLink: false, то при первой привязке, триггера не будет. Еще добавил два порта на соурс к дверям, чтобы можно было тот же с4 привязать к открытию/закрытию двери.

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт.

Ссылки на медиа (изображения/видео) будут добавлены в список изменений на дискорд сервере (не более 10 ссылок каждого вида и 8 МБ суммарного веса (для каждого вида)).
Всё что записано между тегами "CLIgnore" будет игнорироваться при отправке списка изменений.-->

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl: ReeZii
- add: Теперь С4 не триггерятся при привязывании мультитулом.
