### PR TITLE
Add ghost-clown uplink

### DIFF
--- a/Resources/Maps/SS220/Shuttles/lostSoul/honki.yml
+++ b/Resources/Maps/SS220/Shuttles/lostSoul/honki.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 09/17/2025 21:17:04
+  time: 09/17/2025 21:43:12
   entityCount: 441
 maps: []
 grids:
@@ -1010,16 +1010,9 @@ entities:
     - type: Transform
       pos: 6.4719753,-1.1571356
       parent: 2
-  - type: Store
-    name: store-preset-name-uplink
-    categories:
-    - UplinkWearablesClown
-    - AdditionalClown
-    - TrinketsClown
-    currencyWhitelist:
-    - TrashBananaPeel
-    balance:
-      TrashBananaPeel: 100
+    - type: Store
+      balance:
+        TrashBananaPeel: 100
 - proto: CluwneHorn
   entities:
   - uid: 26
@@ -1776,14 +1769,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 220
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-5.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
 - proto: GasPipeBend
   entities:
   - uid: 221
@@ -2272,6 +2257,12 @@ entities:
       color: '#0335FCFF'
 - proto: GasVentPump
   entities:
+  - uid: 1
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 2
   - uid: 282
     components:
     - type: Transform

--- a/Resources/Maps/SS220/Shuttles/lostSoul/honki.yml
+++ b/Resources/Maps/SS220/Shuttles/lostSoul/honki.yml
@@ -1,6 +1,17 @@
 meta:
-  format: 6
-  postmapinit: false
+  format: 7
+  category: Grid
+  engineVersion: 266.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 09/17/2025 21:17:04
+  entityCount: 441
+maps: []
+grids:
+- 2
+orphans:
+- 2
+nullspace: []
 tilemap:
   0: Space
   20: FloorCarpetClown
@@ -10,7 +21,7 @@ tilemap:
 entities:
 - proto: ""
   entities:
-  - uid: 1
+  - uid: 2
     components:
     - type: MetaData
       name: UC-SP "Honk-Honk"
@@ -21,20 +32,20 @@ entities:
       chunks:
         0,0:
           ind: 0,0
-          tiles: GQAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAFAAAAAAAGQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAFAAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-          version: 6
+          tiles: GQAAAAAAABkAAAAAAAAZAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAUAAAAAAAAGQAAAAAAAHkAAAAAAAB4AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAFAAAAAAAAHkAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-          version: 6
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHgAAAAAAAB4AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAAAAAAAAGQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAAAABkAAAAAAAB5AAAAAAAAGQAAAAAAABkAAAAAAAAZAAAAAAAAeQAAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABkAAAAAAAAZAAAAAAAAGQAAAAAAABkAAAAAAAAZAAAAAAAAGQAAAAAAAHkAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAAAAAAAAGQAAAAAAAHkAAAAAAAAZAAAAAAAAGQAAAAAAABkAAAAAAAB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABkAAAAAAAAZAAAAAAAAGQAAAAAAAHkAAAAAAAAZAAAAAAAAGQAAAAAAABkAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAAAAAAAAGQAAAAAAABkAAAAAAAAZAAAAAAAAGQAAAAAAABkAAAAAAAAZAAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAAAAAABkAAAAAAAAZAAAAAAAAeQAAAAAAABkAAAAAAAAZAAAAAAAAGQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
         -1,0:
           ind: -1,0
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAGQAAAAAAGQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAGQAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-          version: 6
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAAZAAAAAAAAGQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHgAAAAAAAB5AAAAAAAAGQAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHkAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAGQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAGQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAGQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAGQAAAAAAGQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAGQAAAAAAGQAAAAAA
-          version: 6
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHgAAAAAAAB4AAAAAAAAeQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAAZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHkAAAAAAAAZAAAAAAAAGQAAAAAAABkAAAAAAAB5AAAAAAAAGQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAAB5AAAAAAAAGQAAAAAAABkAAAAAAAAZAAAAAAAAGQAAAAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAABkAAAAAAAAZAAAAAAAAGQAAAAAAAHkAAAAAAAAZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAAZAAAAAAAAGQAAAAAAABkAAAAAAAB5AAAAAAAAGQAAAAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAGQAAAAAAABkAAAAAAAAZAAAAAAAAGQAAAAAAABkAAAAAAAAZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAABkAAAAAAAAZAAAAAAAAGQAAAAAAAHkAAAAAAAAZAAAAAAAAGQAAAAAAAA==
+          version: 7
     - type: Broadphase
     - type: Physics
       bodyStatus: InAir
@@ -48,6 +59,7 @@ entities:
     - type: SpreaderGrid
     - type: Shuttle
       fTLCooldown: 220
+      dampingModifier: 0.25
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -316,722 +328,742 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+    - type: ImplicitRoof
 - proto: AirCanister
   entities:
-  - uid: 2
-    components:
-    - type: Transform
-      anchored: True
-      pos: -1.5,-2.5
-      parent: 1
-    - type: Physics
-      bodyType: Static
   - uid: 3
     components:
     - type: Transform
       anchored: True
+      pos: -1.5,-2.5
+      parent: 2
+    - type: Physics
+      bodyType: Static
+  - uid: 4
+    components:
+    - type: Transform
+      anchored: True
       pos: 2.5,-2.5
-      parent: 1
+      parent: 2
     - type: Physics
       bodyType: Static
 - proto: AirlockShuttle
   entities:
-  - uid: 4
+  - uid: 5
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-1.5
-      parent: 1
+      parent: 2
 - proto: AltarBananium
-  entities:
-  - uid: 5
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 1
-- proto: APCBasic
   entities:
   - uid: 6
     components:
     - type: Transform
-      pos: 1.5,-3.5
-      parent: 1
-- proto: AtmosDeviceFanTiny
+      pos: 6.5,-1.5
+      parent: 2
+- proto: APCBasic
   entities:
   - uid: 7
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-1.5
-      parent: 1
-- proto: BananaPhoneInstrument
+      pos: 1.5,-3.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: AtmosDeviceFanTiny
   entities:
   - uid: 8
     components:
     - type: Transform
-      pos: -1.6258063,0.9834574
-      parent: 1
-- proto: BananiumDoor
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-1.5
+      parent: 2
+- proto: BananaPhoneInstrument
   entities:
   - uid: 9
     components:
     - type: Transform
+      pos: -1.6258063,0.9834574
+      parent: 2
+- proto: BananiumDoor
+  entities:
+  - uid: 10
+    components:
+    - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-1.5
-      parent: 1
-  - uid: 10
+      parent: 2
+  - uid: 11
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-5.5
-      parent: 1
-  - uid: 11
+      parent: 2
+  - uid: 12
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-5.5
-      parent: 1
-  - uid: 12
+      parent: 2
+  - uid: 13
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-3.5
-      parent: 1
-  - uid: 13
+      parent: 2
+  - uid: 14
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-1.5
-      parent: 1
+      parent: 2
 - proto: BarricadeBlock
-  entities:
-  - uid: 14
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-5.5
-      parent: 1
-- proto: Bed
   entities:
   - uid: 15
     components:
     - type: Transform
-      pos: 3.5,-6.5
-      parent: 1
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 2
+- proto: Bed
+  entities:
   - uid: 16
     components:
     - type: Transform
-      pos: 3.5,-4.5
-      parent: 1
+      pos: 3.5,-6.5
+      parent: 2
   - uid: 17
     components:
     - type: Transform
-      pos: 5.5,-6.5
-      parent: 1
+      pos: 3.5,-4.5
+      parent: 2
   - uid: 18
     components:
     - type: Transform
-      pos: 5.5,-4.5
-      parent: 1
-- proto: BedsheetSpawner
-  entities:
+      pos: 5.5,-6.5
+      parent: 2
   - uid: 19
     components:
     - type: Transform
-      pos: 3.5,-6.5
-      parent: 1
+      pos: 5.5,-4.5
+      parent: 2
+- proto: BedsheetSpawner
+  entities:
   - uid: 20
     components:
     - type: Transform
-      pos: 5.5,-6.5
-      parent: 1
+      pos: 3.5,-6.5
+      parent: 2
   - uid: 21
     components:
     - type: Transform
-      pos: 3.5,-4.5
-      parent: 1
+      pos: 5.5,-6.5
+      parent: 2
   - uid: 22
     components:
     - type: Transform
-      pos: 5.5,-4.5
-      parent: 1
-- proto: BikeHornImplanter
-  entities:
-  - uid: 24
-    components:
-    - type: Transform
-      parent: 23
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 29
-    components:
-    - type: Transform
-      parent: 28
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: CableApcExtension
-  entities:
-  - uid: 33
-    components:
-    - type: Transform
-      pos: -0.5,-2.5
-      parent: 1
-  - uid: 34
-    components:
-    - type: Transform
-      pos: -0.5,-1.5
-      parent: 1
-  - uid: 35
-    components:
-    - type: Transform
-      pos: 1.5,-3.5
-      parent: 1
-  - uid: 36
-    components:
-    - type: Transform
-      pos: 1.5,-4.5
-      parent: 1
-  - uid: 37
-    components:
-    - type: Transform
-      pos: 1.5,-5.5
-      parent: 1
-  - uid: 38
-    components:
-    - type: Transform
-      pos: 1.5,-6.5
-      parent: 1
-  - uid: 39
-    components:
-    - type: Transform
-      pos: 0.5,-5.5
-      parent: 1
-  - uid: 40
-    components:
-    - type: Transform
-      pos: -0.5,-5.5
-      parent: 1
-  - uid: 41
-    components:
-    - type: Transform
-      pos: -0.5,-6.5
-      parent: 1
-  - uid: 42
-    components:
-    - type: Transform
-      pos: -0.5,-7.5
-      parent: 1
-  - uid: 43
-    components:
-    - type: Transform
-      pos: 1.5,-2.5
-      parent: 1
-  - uid: 44
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
-      parent: 1
-  - uid: 45
-    components:
-    - type: Transform
-      pos: -1.5,-5.5
-      parent: 1
-  - uid: 46
-    components:
-    - type: Transform
-      pos: -2.5,-5.5
-      parent: 1
-  - uid: 47
-    components:
-    - type: Transform
-      pos: -3.5,-5.5
-      parent: 1
-  - uid: 48
-    components:
-    - type: Transform
-      pos: -4.5,-5.5
-      parent: 1
-  - uid: 49
-    components:
-    - type: Transform
-      pos: 3.5,-5.5
-      parent: 1
-  - uid: 50
-    components:
-    - type: Transform
-      pos: 4.5,-5.5
-      parent: 1
-  - uid: 51
-    components:
-    - type: Transform
-      pos: 5.5,-5.5
-      parent: 1
-  - uid: 52
-    components:
-    - type: Transform
-      pos: -0.5,-2.5
-      parent: 1
-  - uid: 53
-    components:
-    - type: Transform
-      pos: -0.5,-1.5
-      parent: 1
-  - uid: 54
-    components:
-    - type: Transform
-      pos: -0.5,-0.5
-      parent: 1
-  - uid: 55
-    components:
-    - type: Transform
-      pos: 1.5,-1.5
-      parent: 1
-  - uid: 56
-    components:
-    - type: Transform
-      pos: 4.5,-1.5
-      parent: 1
-  - uid: 57
-    components:
-    - type: Transform
-      pos: 1.5,-0.5
-      parent: 1
-  - uid: 58
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 1
-  - uid: 59
-    components:
-    - type: Transform
-      pos: 1.5,1.5
-      parent: 1
-  - uid: 60
-    components:
-    - type: Transform
-      pos: -0.5,1.5
-      parent: 1
-  - uid: 61
-    components:
-    - type: Transform
-      pos: -0.5,0.5
-      parent: 1
-  - uid: 62
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 1
-  - uid: 63
-    components:
-    - type: Transform
-      pos: 3.5,-1.5
-      parent: 1
-  - uid: 64
-    components:
-    - type: Transform
-      pos: 5.5,-1.5
-      parent: 1
-  - uid: 65
-    components:
-    - type: Transform
-      pos: -2.5,-1.5
-      parent: 1
-  - uid: 66
-    components:
-    - type: Transform
-      pos: -3.5,-1.5
-      parent: 1
-  - uid: 67
-    components:
-    - type: Transform
-      pos: -4.5,-1.5
-      parent: 1
-  - uid: 68
-    components:
-    - type: Transform
-      pos: -5.5,-1.5
-      parent: 1
-  - uid: 69
-    components:
-    - type: Transform
-      pos: -4.5,-0.5
-      parent: 1
-  - uid: 70
-    components:
-    - type: Transform
-      pos: -4.5,0.5
-      parent: 1
-  - uid: 71
-    components:
-    - type: Transform
-      pos: 5.5,-0.5
-      parent: 1
-  - uid: 72
-    components:
-    - type: Transform
-      pos: 5.5,0.5
-      parent: 1
-  - uid: 73
-    components:
-    - type: Transform
-      pos: 6.5,-5.5
-      parent: 1
-  - uid: 74
-    components:
-    - type: Transform
-      pos: 5.5,-5.5
-      parent: 1
-  - uid: 75
-    components:
-    - type: Transform
-      pos: 4.5,-6.5
-      parent: 1
-  - uid: 76
-    components:
-    - type: Transform
-      pos: 4.5,-7.5
-      parent: 1
-  - uid: 77
-    components:
-    - type: Transform
-      pos: -3.5,-7.5
-      parent: 1
-  - uid: 78
-    components:
-    - type: Transform
-      pos: -3.5,-6.5
-      parent: 1
-  - uid: 79
-    components:
-    - type: Transform
-      pos: -5.5,-5.5
-      parent: 1
-  - uid: 80
-    components:
-    - type: Transform
-      pos: -0.5,-3.5
-      parent: 1
-  - uid: 81
-    components:
-    - type: Transform
-      pos: 0.5,-1.5
-      parent: 1
-  - uid: 82
-    components:
-    - type: Transform
-      pos: -1.5,-1.5
-      parent: 1
-  - uid: 83
-    components:
-    - type: Transform
-      pos: 2.5,-5.5
-      parent: 1
-- proto: CableHV
-  entities:
-  - uid: 84
-    components:
-    - type: Transform
-      pos: 0.5,-5.5
-      parent: 1
-  - uid: 85
-    components:
-    - type: Transform
-      pos: 0.5,-7.5
-      parent: 1
-  - uid: 86
-    components:
-    - type: Transform
-      pos: 0.5,-8.5
-      parent: 1
-  - uid: 87
-    components:
-    - type: Transform
-      pos: 0.5,-6.5
-      parent: 1
-  - uid: 88
-    components:
-    - type: Transform
-      pos: -0.5,-3.5
-      parent: 1
-  - uid: 89
-    components:
-    - type: Transform
-      pos: 0.5,-4.5
-      parent: 1
-  - uid: 90
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
-      parent: 1
-- proto: CableMV
-  entities:
-  - uid: 91
-    components:
-    - type: Transform
-      pos: 0.5,-7.5
-      parent: 1
-  - uid: 92
-    components:
-    - type: Transform
-      pos: 1.5,-3.5
-      parent: 1
-  - uid: 93
-    components:
-    - type: Transform
-      pos: 0.5,-6.5
-      parent: 1
-  - uid: 94
-    components:
-    - type: Transform
-      pos: 0.5,-5.5
-      parent: 1
-  - uid: 95
-    components:
-    - type: Transform
-      pos: 0.5,-4.5
-      parent: 1
-  - uid: 96
-    components:
-    - type: Transform
-      pos: 1.5,-4.5
-      parent: 1
-  - uid: 97
-    components:
-    - type: Transform
-      pos: -0.5,-3.5
-      parent: 1
-  - uid: 98
-    components:
-    - type: Transform
-      pos: 0.5,-7.5
-      parent: 1
-  - uid: 99
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
-      parent: 1
-  - uid: 100
-    components:
-    - type: Transform
-      pos: -0.5,-7.5
-      parent: 1
-  - uid: 101
-    components:
-    - type: Transform
-      pos: 1.5,-7.5
-      parent: 1
-- proto: CarpetBlue
-  entities:
-  - uid: 102
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,-4.5
-      parent: 1
-  - uid: 103
+      parent: 2
+  - uid: 23
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-4.5
-      parent: 1
-  - uid: 104
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-4.5
-      parent: 1
-- proto: CarpetPink
-  entities:
-  - uid: 105
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,0.5
-      parent: 1
-  - uid: 106
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-0.5
-      parent: 1
-  - uid: 107
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-1.5
-      parent: 1
-  - uid: 108
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,0.5
-      parent: 1
-  - uid: 109
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-0.5
-      parent: 1
-  - uid: 110
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-1.5
-      parent: 1
-  - uid: 111
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,0.5
-      parent: 1
-  - uid: 112
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-0.5
-      parent: 1
-  - uid: 113
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-1.5
-      parent: 1
-- proto: CarpetPurple
-  entities:
-  - uid: 114
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-6.5
-      parent: 1
-  - uid: 115
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-6.5
-      parent: 1
-  - uid: 116
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-6.5
-      parent: 1
-- proto: ChairPilotSeat
-  entities:
-  - uid: 117
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,1.5
-      parent: 1
-- proto: CigaretteBanana
-  entities:
-  - uid: 119
-    components:
-    - type: Transform
-      parent: 118
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 120
-    components:
-    - type: Transform
-      parent: 118
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 121
-    components:
-    - type: Transform
-      parent: 118
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: ClothingOuterHardsuitClown
-  entities:
-  - uid: 122
-    components:
-    - type: Transform
-      parent: 118
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 125
-    components:
-    - type: Transform
-      parent: 124
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 129
-    components:
-    - type: Transform
-      parent: 128
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: ClothingOuterWinterClown
-  entities:
-  - uid: 130
-    components:
-    - type: Transform
-      parent: 128
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: ClownRecorder
-  entities:
-  - uid: 132
-    components:
-    - type: Transform
-      pos: 2.7283604,1.1292907
-      parent: 1
-- proto: CluwneHorn
+      parent: 2
+- proto: BikeHornImplanter
   entities:
   - uid: 25
     components:
     - type: Transform
-      parent: 23
+      parent: 24
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 30
     components:
     - type: Transform
-      parent: 28
+      parent: 29
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: CableApcExtension
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 2
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 2
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 2
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 2
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 2
+  - uid: 43
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 2
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 2
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 2
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 2
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 2
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 2
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 2
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 2
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 2
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 2
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 2
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 2
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 2
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 2
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 2
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 2
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 2
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 2
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 2
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 2
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 4.5,-6.5
+      parent: 2
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 2
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 2
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 2
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 2
+- proto: CableHV
+  entities:
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 2
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 2
+  - uid: 89
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+- proto: CableMV
+  entities:
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 2
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+- proto: CarpetBlue
+  entities:
+  - uid: 103
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 2
+  - uid: 104
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-4.5
+      parent: 2
+  - uid: 105
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 2
+- proto: CarpetPink
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 107
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 2
+  - uid: 108
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 2
+  - uid: 109
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 110
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 2
+  - uid: 111
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 112
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 2
+  - uid: 113
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 2
+  - uid: 114
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 2
+- proto: CarpetPurple
+  entities:
+  - uid: 115
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 2
+  - uid: 116
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 2
+  - uid: 117
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 2
+- proto: ChairPilotSeat
+  entities:
+  - uid: 118
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 2
+- proto: CigaretteBanana
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      parent: 119
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 121
+    components:
+    - type: Transform
+      parent: 119
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 122
+    components:
+    - type: Transform
+      parent: 119
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingOuterHardsuitClown
+  entities:
+  - uid: 123
+    components:
+    - type: Transform
+      parent: 119
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 126
+    components:
+    - type: Transform
+      parent: 125
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 130
+    components:
+    - type: Transform
+      parent: 129
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingOuterWinterClown
+  entities:
+  - uid: 131
+    components:
+    - type: Transform
+      parent: 129
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClownRecorder
+  entities:
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 2.7283604,1.1292907
+      parent: 2
+- proto: ClownUplink
+  entities:
+  - uid: 442
+    components:
+    - type: Transform
+      pos: 6.4719753,-1.1571356
+      parent: 2
+  - type: Store
+    name: store-preset-name-uplink
+    categories:
+    - UplinkWearablesClown
+    - AdditionalClown
+    - TrinketsClown
+    currencyWhitelist:
+    - TrashBananaPeel
+    balance:
+      TrashBananaPeel: 100
+- proto: CluwneHorn
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      parent: 24
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 31
+    components:
+    - type: Transform
+      parent: 29
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ComfyChair
   entities:
-  - uid: 133
+  - uid: 134
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,0.5
-      parent: 1
-  - uid: 134
+      parent: 2
+  - uid: 135
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,0.5
-      parent: 1
+      parent: 2
 - proto: ComputerShuttle
-  entities:
-  - uid: 135
-    components:
-    - type: Transform
-      pos: 0.5,2.5
-      parent: 1
-- proto: CrateCargoGambling
   entities:
   - uid: 136
     components:
     - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+- proto: CrateCargoGambling
+  entities:
+  - uid: 137
+    components:
+    - type: Transform
       pos: -0.5,-2.5
-      parent: 1
+      parent: 2
     - type: EntityStorage
       air:
         volume: 200
@@ -1052,11 +1084,11 @@ entities:
         - 0
 - proto: CratePirate
   entities:
-  - uid: 23
+  - uid: 24
     components:
     - type: Transform
       pos: 4.5,-0.5
-      parent: 1
+      parent: 2
     - type: EntityStorage
       air:
         volume: 200
@@ -1081,19 +1113,19 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 27
-          - 25
-          - 24
+          - 28
           - 26
+          - 25
+          - 27
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
-  - uid: 28
+  - uid: 29
     components:
     - type: Transform
       pos: 4.5,-2.5
-      parent: 1
+      parent: 2
     - type: EntityStorage
       air:
         volume: 200
@@ -1118,19 +1150,19 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 30
           - 31
           - 32
-          - 29
+          - 33
+          - 30
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
-  - uid: 137
+  - uid: 138
     components:
     - type: Transform
       pos: 6.5,-2.5
-      parent: 1
+      parent: 2
     - type: EntityStorage
       air:
         volume: 200
@@ -1155,26 +1187,26 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 138
           - 139
           - 140
           - 141
           - 142
-          - 148
           - 143
+          - 149
           - 144
           - 145
           - 146
           - 147
+          - 148
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
-  - uid: 149
+  - uid: 150
     components:
     - type: Transform
       pos: 6.5,-0.5
-      parent: 1
+      parent: 2
     - type: EntityStorage
       air:
         volume: 200
@@ -1199,9 +1231,10 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 159
-          - 158
           - 160
+          - 159
+          - 161
+          - 158
           - 157
           - 156
           - 155
@@ -1209,1323 +1242,1322 @@ entities:
           - 153
           - 152
           - 151
-          - 150
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: CrayonRainbow
   entities:
-  - uid: 161
+  - uid: 162
     components:
     - type: Transform
       pos: 2.3752804,1.3242286
-      parent: 1
+      parent: 2
 - proto: DehydratedSpaceCarp
   entities:
-  - uid: 26
+  - uid: 27
     components:
     - type: Transform
-      parent: 23
+      parent: 24
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 31
+  - uid: 32
     components:
     - type: Transform
-      parent: 28
+      parent: 29
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: DisposalBend
   entities:
-  - uid: 162
+  - uid: 163
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-6.5
-      parent: 1
-  - uid: 163
+      parent: 2
+  - uid: 164
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-6.5
-      parent: 1
-  - uid: 164
+      parent: 2
+  - uid: 165
     components:
     - type: Transform
       pos: 0.5,-4.5
-      parent: 1
-  - uid: 165
+      parent: 2
+  - uid: 166
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-4.5
-      parent: 1
-  - uid: 166
+      parent: 2
+  - uid: 167
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-6.5
-      parent: 1
-  - uid: 167
+      parent: 2
+  - uid: 168
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-6.5
-      parent: 1
-  - uid: 168
+      parent: 2
+  - uid: 169
     components:
     - type: Transform
       pos: -2.5,-4.5
-      parent: 1
-  - uid: 169
+      parent: 2
+  - uid: 170
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-4.5
-      parent: 1
-  - uid: 170
+      parent: 2
+  - uid: 171
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-6.5
-      parent: 1
-  - uid: 171
+      parent: 2
+  - uid: 172
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-6.5
-      parent: 1
-  - uid: 172
+      parent: 2
+  - uid: 173
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-1.5
-      parent: 1
-  - uid: 173
+      parent: 2
+  - uid: 174
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-1.5
-      parent: 1
-  - uid: 174
+      parent: 2
+  - uid: 175
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,1.5
-      parent: 1
-  - uid: 175
+      parent: 2
+  - uid: 176
     components:
     - type: Transform
       pos: 1.5,1.5
-      parent: 1
-  - uid: 176
+      parent: 2
+  - uid: 177
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-1.5
-      parent: 1
-  - uid: 177
+      parent: 2
+  - uid: 178
     components:
     - type: Transform
       pos: 4.5,-1.5
-      parent: 1
-  - uid: 178
+      parent: 2
+  - uid: 179
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-2.5
-      parent: 1
-  - uid: 179
-    components:
-    - type: Transform
-      pos: 5.5,-2.5
-      parent: 1
-- proto: DisposalPipe
-  entities:
+      parent: 2
   - uid: 180
     components:
     - type: Transform
-      pos: 1.5,-3.5
-      parent: 1
+      pos: 5.5,-2.5
+      parent: 2
+- proto: DisposalPipe
+  entities:
   - uid: 181
     components:
     - type: Transform
-      pos: 1.5,-4.5
-      parent: 1
+      pos: 1.5,-3.5
+      parent: 2
   - uid: 182
     components:
     - type: Transform
-      pos: 1.5,-5.5
-      parent: 1
+      pos: 1.5,-4.5
+      parent: 2
   - uid: 183
     components:
     - type: Transform
-      pos: 0.5,-5.5
-      parent: 1
+      pos: 1.5,-5.5
+      parent: 2
   - uid: 184
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-5.5
-      parent: 1
+      pos: 0.5,-5.5
+      parent: 2
   - uid: 185
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,-5.5
-      parent: 1
+      pos: -0.5,-5.5
+      parent: 2
   - uid: 186
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-5.5
-      parent: 1
+      pos: -2.5,-5.5
+      parent: 2
   - uid: 187
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-5.5
-      parent: 1
+      pos: -3.5,-5.5
+      parent: 2
   - uid: 188
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 189
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-6.5
-      parent: 1
-  - uid: 189
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-4.5
-      parent: 1
+      parent: 2
   - uid: 190
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-3.5
-      parent: 1
+      pos: -4.5,-4.5
+      parent: 2
   - uid: 191
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-2.5
-      parent: 1
+      pos: -4.5,-3.5
+      parent: 2
   - uid: 192
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-1.5
-      parent: 1
+      rot: 3.141592653589793 rad
+      pos: -4.5,-2.5
+      parent: 2
   - uid: 193
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.5,-1.5
-      parent: 1
+      pos: -3.5,-1.5
+      parent: 2
   - uid: 194
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -1.5,-1.5
-      parent: 1
+      pos: -2.5,-1.5
+      parent: 2
   - uid: 195
     components:
     - type: Transform
-      pos: -0.5,-0.5
-      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 2
   - uid: 196
     components:
     - type: Transform
-      pos: -0.5,0.5
-      parent: 1
+      pos: -0.5,-0.5
+      parent: 2
   - uid: 197
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 198
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,1.5
-      parent: 1
-  - uid: 198
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,0.5
-      parent: 1
+      parent: 2
   - uid: 199
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,-0.5
-      parent: 1
+      pos: 1.5,0.5
+      parent: 2
   - uid: 200
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-1.5
-      parent: 1
+      rot: 3.141592653589793 rad
+      pos: 1.5,-0.5
+      parent: 2
   - uid: 201
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,-1.5
-      parent: 1
+      pos: 2.5,-1.5
+      parent: 2
   - uid: 202
     components:
     - type: Transform
-      pos: 5.5,-3.5
-      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 2
   - uid: 203
     components:
     - type: Transform
-      pos: 5.5,-4.5
-      parent: 1
-- proto: DisposalTrunk
-  entities:
+      pos: 5.5,-3.5
+      parent: 2
   - uid: 204
     components:
     - type: Transform
-      pos: 1.5,-2.5
-      parent: 1
+      pos: 5.5,-4.5
+      parent: 2
+- proto: DisposalTrunk
+  entities:
   - uid: 205
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 206
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-5.5
-      parent: 1
+      parent: 2
 - proto: DisposalUnit
   entities:
-  - uid: 206
+  - uid: 207
     components:
     - type: Transform
       pos: 1.5,-2.5
-      parent: 1
+      parent: 2
 - proto: EmergencyFunnyOxygenTankFilled
   entities:
-  - uid: 123
+  - uid: 124
     components:
     - type: Transform
-      parent: 118
+      parent: 119
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 126
+  - uid: 127
     components:
     - type: Transform
-      parent: 124
+      parent: 125
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 131
+  - uid: 132
     components:
     - type: Transform
-      parent: 128
+      parent: 129
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: FloorBananiumEntity
   entities:
-  - uid: 207
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-7.5
-      parent: 1
   - uid: 208
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,-7.5
-      parent: 1
+      pos: -0.5,-7.5
+      parent: 2
   - uid: 209
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,-7.5
-      parent: 1
+      pos: 0.5,-7.5
+      parent: 2
   - uid: 210
     components:
     - type: Transform
-      pos: -1.5,-6.5
-      parent: 1
+      rot: 3.141592653589793 rad
+      pos: 1.5,-7.5
+      parent: 2
   - uid: 211
     components:
     - type: Transform
-      pos: -1.5,-4.5
-      parent: 1
+      pos: -1.5,-6.5
+      parent: 2
   - uid: 212
     components:
     - type: Transform
-      pos: 0.5,-3.5
-      parent: 1
-- proto: FoodBanana
-  entities:
-  - uid: 138
+      pos: -1.5,-4.5
+      parent: 2
+  - uid: 213
     components:
     - type: Transform
-      parent: 137
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
+      pos: 0.5,-3.5
+      parent: 2
+- proto: FoodBanana
+  entities:
   - uid: 139
     components:
     - type: Transform
-      parent: 137
+      parent: 138
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 140
     components:
     - type: Transform
-      parent: 137
+      parent: 138
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 141
     components:
     - type: Transform
-      parent: 137
+      parent: 138
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 150
+  - uid: 142
     components:
     - type: Transform
-      parent: 149
+      parent: 138
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 151
     components:
     - type: Transform
-      parent: 149
+      parent: 150
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 152
     components:
     - type: Transform
-      parent: 149
+      parent: 150
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 153
     components:
     - type: Transform
-      parent: 149
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: FoodBreadBanana
-  entities:
-  - uid: 213
-    components:
-    - type: Transform
-      pos: 7.418606,-5.8712335
-      parent: 1
-- proto: FoodBurgerClown
-  entities:
-  - uid: 214
-    components:
-    - type: Transform
-      pos: -1.3341398,1.2959573
-      parent: 1
-  - uid: 215
-    components:
-    - type: Transform
-      pos: -1.5841398,1.5042907
-      parent: 1
-- proto: FoodCakeClown
-  entities:
-  - uid: 216
-    components:
-    - type: Transform
-      pos: 2.4366937,0.6397073
-      parent: 1
-- proto: FoodMeatClown
-  entities:
-  - uid: 217
-    components:
-    - type: Transform
-      pos: 3.4782665,-4.592343
-      parent: 1
-- proto: FoodPieBananaCream
-  entities:
-  - uid: 142
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 143
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 144
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 145
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 146
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 147
-    components:
-    - type: Transform
-      parent: 137
+      parent: 150
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 154
     components:
     - type: Transform
-      parent: 149
+      parent: 150
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: FoodBreadBanana
+  entities:
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 7.418606,-5.8712335
+      parent: 2
+- proto: FoodBurgerClown
+  entities:
+  - uid: 215
+    components:
+    - type: Transform
+      pos: -1.3341398,1.2959573
+      parent: 2
+  - uid: 216
+    components:
+    - type: Transform
+      pos: -1.5841398,1.5042907
+      parent: 2
+- proto: FoodCakeClown
+  entities:
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 2.4366937,0.6397073
+      parent: 2
+- proto: FoodMeatClown
+  entities:
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 3.4782665,-4.592343
+      parent: 2
+- proto: FoodPieBananaCream
+  entities:
+  - uid: 143
+    components:
+    - type: Transform
+      parent: 138
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 144
+    components:
+    - type: Transform
+      parent: 138
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 145
+    components:
+    - type: Transform
+      parent: 138
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 146
+    components:
+    - type: Transform
+      parent: 138
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 147
+    components:
+    - type: Transform
+      parent: 138
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 148
+    components:
+    - type: Transform
+      parent: 138
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 155
     components:
     - type: Transform
-      parent: 149
+      parent: 150
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 156
     components:
     - type: Transform
-      parent: 149
+      parent: 150
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 157
     components:
     - type: Transform
-      parent: 149
+      parent: 150
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 158
     components:
     - type: Transform
-      parent: 149
+      parent: 150
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 159
     components:
     - type: Transform
-      parent: 149
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: GasPassiveVent
-  entities:
-  - uid: 218
-    components:
-    - type: Transform
-      pos: 5.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 219
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-- proto: GasPipeBend
-  entities:
-  - uid: 220
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 221
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 222
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 223
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 224
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 225
-    components:
-    - type: Transform
-      pos: 6.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 226
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 227
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 228
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 229
-    components:
-    - type: Transform
-      pos: 2.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 230
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 231
-    components:
-    - type: Transform
-      pos: 5.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 232
-    components:
-    - type: Transform
-      pos: 1.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 233
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 234
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 235
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-- proto: GasPipeFourway
-  entities:
-  - uid: 236
-    components:
-    - type: Transform
-      pos: 0.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 237
-    components:
-    - type: Transform
-      pos: 5.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 238
-    components:
-    - type: Transform
-      pos: 0.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-- proto: GasPipeStraight
-  entities:
-  - uid: 239
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 240
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 241
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 242
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 243
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 244
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 245
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 246
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 247
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 248
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 249
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 250
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 251
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 252
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 253
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 254
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 255
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 256
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 257
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 258
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 259
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 260
-    components:
-    - type: Transform
-      pos: 5.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 261
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 262
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 263
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 264
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 265
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 266
-    components:
-    - type: Transform
-      pos: 6.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 267
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 268
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 269
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 270
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 271
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 272
-    components:
-    - type: Transform
-      pos: -0.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 273
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 274
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 275
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-- proto: GasPipeTJunction
-  entities:
-  - uid: 276
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 277
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 278
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-- proto: GasPort
-  entities:
-  - uid: 279
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 280
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-- proto: GasVentPump
-  entities:
-  - uid: 281
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 282
-    components:
-    - type: Transform
-      pos: 0.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 283
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 284
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 285
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-- proto: GasVentScrubber
-  entities:
-  - uid: 286
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 287
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 288
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 289
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 290
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 291
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-- proto: GeneratorBasic15kW
-  entities:
-  - uid: 292
-    components:
-    - type: Transform
-      pos: 0.5,-7.5
-      parent: 1
-- proto: GeneratorWallmountAPU
-  entities:
-  - uid: 293
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-8.5
-      parent: 1
-- proto: GoldenBikeHorn
-  entities:
-  - uid: 294
-    components:
-    - type: Transform
-      pos: 6.4591703,-1.2964956
-      parent: 1
-- proto: GravityGeneratorMini
-  entities:
-  - uid: 295
-    components:
-    - type: Transform
-      pos: -0.5,-7.5
-      parent: 1
-- proto: Grille
-  entities:
-  - uid: 296
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,2.5
-      parent: 1
-  - uid: 297
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,3.5
-      parent: 1
-  - uid: 298
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,3.5
-      parent: 1
-  - uid: 299
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,3.5
-      parent: 1
-  - uid: 300
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,2.5
-      parent: 1
-  - uid: 301
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,0.5
-      parent: 1
-  - uid: 302
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,0.5
-      parent: 1
-  - uid: 303
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-5.5
-      parent: 1
-  - uid: 304
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-6.5
-      parent: 1
-  - uid: 305
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-5.5
-      parent: 1
-  - uid: 306
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-6.5
-      parent: 1
-  - uid: 307
-    components:
-    - type: Transform
-      pos: -1.5,-6.5
-      parent: 1
-  - uid: 308
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 1
-- proto: GrilleDiagonal
-  entities:
-  - uid: 309
-    components:
-    - type: Transform
-      pos: -2.5,2.5
-      parent: 1
-  - uid: 310
-    components:
-    - type: Transform
-      pos: -1.5,3.5
-      parent: 1
-  - uid: 311
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,3.5
-      parent: 1
-  - uid: 312
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,2.5
-      parent: 1
-  - uid: 313
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,2.5
-      parent: 1
-  - uid: 314
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,2.5
-      parent: 1
-  - uid: 315
-    components:
-    - type: Transform
-      pos: -6.5,0.5
-      parent: 1
-  - uid: 316
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,0.5
-      parent: 1
-- proto: Gyroscope
-  entities:
-  - uid: 317
-    components:
-    - type: Transform
-      pos: 1.5,-7.5
-      parent: 1
-- proto: LampBanana
-  entities:
-  - uid: 318
-    components:
-    - type: Transform
-      pos: 2.645027,1.7855407
-      parent: 1
-    - type: ContainerContainer
-      containers:
-        cell_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 319
-- proto: LauncherCreamPie
-  entities:
-  - uid: 148
-    components:
-    - type: Transform
-      parent: 137
+      parent: 150
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 160
     components:
     - type: Transform
-      parent: 149
+      parent: 150
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: GasPassiveVent
+  entities:
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 220
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 221
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 222
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 223
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 224
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 225
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 227
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 228
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 229
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 231
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 235
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 236
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 240
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 241
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 242
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 243
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 244
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 245
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 246
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 247
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 248
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 249
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 250
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 251
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 252
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 253
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 254
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 255
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 256
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 257
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 258
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 260
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 261
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 262
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 263
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 264
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 265
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 266
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 267
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 268
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 269
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 270
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 271
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 272
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 273
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 274
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 275
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 276
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 277
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 278
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 279
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPort
+  entities:
+  - uid: 280
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 281
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 282
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 283
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 284
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 285
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 286
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 287
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 288
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 289
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 290
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 291
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 292
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 293
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+- proto: GeneratorWallmountAPU
+  entities:
+  - uid: 294
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-8.5
+      parent: 2
+- proto: GoldenBikeHorn
+  entities:
+  - uid: 295
+    components:
+    - type: Transform
+      pos: -1.4899354,0.6324849
+      parent: 2
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 296
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+- proto: Grille
+  entities:
+  - uid: 297
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 298
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,3.5
+      parent: 2
+  - uid: 299
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,3.5
+      parent: 2
+  - uid: 300
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,3.5
+      parent: 2
+  - uid: 301
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 2
+  - uid: 302
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,0.5
+      parent: 2
+  - uid: 303
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 304
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 305
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-6.5
+      parent: 2
+  - uid: 306
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-5.5
+      parent: 2
+  - uid: 307
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-6.5
+      parent: 2
+  - uid: 308
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 2
+  - uid: 309
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+- proto: GrilleDiagonal
+  entities:
+  - uid: 310
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 2
+  - uid: 311
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 2
+  - uid: 312
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 2
+  - uid: 313
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 2
+  - uid: 314
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 2
+  - uid: 315
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 316
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 2
+  - uid: 317
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,0.5
+      parent: 2
+- proto: Gyroscope
+  entities:
+  - uid: 318
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+- proto: LampBanana
+  entities:
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 2.645027,1.7855407
+      parent: 2
+    - type: ContainerContainer
+      containers:
+        cell_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 320
+- proto: LauncherCreamPie
+  entities:
+  - uid: 149
+    components:
+    - type: Transform
+      parent: 138
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 161
+    components:
+    - type: Transform
+      parent: 150
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: Paper
   entities:
-  - uid: 320
+  - uid: 321
     components:
     - type: Transform
       pos: 2.3294551,1.4404249
-      parent: 1
+      parent: 2
     - type: Paper
       content: >+
         [head=2]И такь...[/head]
@@ -2561,11 +2593,11 @@ entities:
 
 - proto: PaperOffice
   entities:
-  - uid: 321
+  - uid: 322
     components:
     - type: Transform
       pos: 5.539774,1.4090358
-      parent: 1
+      parent: 2
     - type: Paper
       content: >
         Ты думал тут что-то будет?
@@ -2573,343 +2605,343 @@ entities:
         О-о-о... нет.
 - proto: PlasmaWindow
   entities:
-  - uid: 322
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,3.5
-      parent: 1
   - uid: 323
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,3.5
-      parent: 1
+      pos: -0.5,3.5
+      parent: 2
   - uid: 324
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,3.5
-      parent: 1
+      pos: 0.5,3.5
+      parent: 2
   - uid: 325
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,2.5
-      parent: 1
+      pos: 1.5,3.5
+      parent: 2
   - uid: 326
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,2.5
-      parent: 1
+      pos: -1.5,2.5
+      parent: 2
   - uid: 327
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,0.5
-      parent: 1
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 2
   - uid: 328
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,0.5
-      parent: 1
+      pos: -5.5,0.5
+      parent: 2
   - uid: 329
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-5.5
-      parent: 1
+      pos: 6.5,0.5
+      parent: 2
   - uid: 330
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-6.5
-      parent: 1
+      pos: -5.5,-5.5
+      parent: 2
   - uid: 331
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,-6.5
-      parent: 1
+      pos: -5.5,-6.5
+      parent: 2
   - uid: 332
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,-5.5
-      parent: 1
+      pos: 6.5,-6.5
+      parent: 2
   - uid: 333
     components:
     - type: Transform
-      pos: -1.5,-6.5
-      parent: 1
+      rot: 3.141592653589793 rad
+      pos: 6.5,-5.5
+      parent: 2
   - uid: 334
     components:
     - type: Transform
-      pos: -1.5,-4.5
-      parent: 1
-- proto: PlasmaWindowDiagonal
-  entities:
+      pos: -1.5,-6.5
+      parent: 2
   - uid: 335
     components:
     - type: Transform
-      pos: -2.5,2.5
-      parent: 1
+      pos: -1.5,-4.5
+      parent: 2
+- proto: PlasmaWindowDiagonal
+  entities:
   - uid: 336
     components:
     - type: Transform
-      pos: -1.5,3.5
-      parent: 1
+      pos: -2.5,2.5
+      parent: 2
   - uid: 337
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,3.5
-      parent: 1
+      pos: -1.5,3.5
+      parent: 2
   - uid: 338
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,2.5
-      parent: 1
+      pos: 2.5,3.5
+      parent: 2
   - uid: 339
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 2
+  - uid: 340
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,2.5
-      parent: 1
-  - uid: 340
+      parent: 2
+  - uid: 341
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,2.5
-      parent: 1
-  - uid: 341
+      parent: 2
+  - uid: 342
     components:
     - type: Transform
       pos: -6.5,0.5
-      parent: 1
-  - uid: 342
+      parent: 2
+  - uid: 343
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,0.5
-      parent: 1
+      parent: 2
 - proto: PlasticBanana
-  entities:
-  - uid: 343
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5228624,1.4268955
-      parent: 1
-- proto: PowerCellHigh
-  entities:
-  - uid: 319
-    components:
-    - type: Transform
-      parent: 318
-    - type: Physics
-      canCollide: False
-- proto: PoweredlightLED
   entities:
   - uid: 344
     components:
     - type: Transform
-      pos: 4.5,-4.5
-      parent: 1
+      rot: 3.141592653589793 rad
+      pos: -4.5228624,1.4268955
+      parent: 2
+- proto: PowerCellHigh
+  entities:
+  - uid: 320
+    components:
+    - type: Transform
+      parent: 319
+    - type: Physics
+      canCollide: False
+- proto: PoweredlightLED
+  entities:
   - uid: 345
     components:
     - type: Transform
-      pos: -3.5,-4.5
-      parent: 1
+      pos: 4.5,-4.5
+      parent: 2
   - uid: 346
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 2
+  - uid: 347
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-0.5
-      parent: 1
-  - uid: 347
+      parent: 2
+  - uid: 348
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-0.5
-      parent: 1
+      parent: 2
 - proto: PoweredlightOrange
-  entities:
-  - uid: 348
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-7.5
-      parent: 1
-- proto: PoweredlightPink
   entities:
   - uid: 349
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-6.5
-      parent: 1
+      pos: 0.5,-7.5
+      parent: 2
+- proto: PoweredlightPink
+  entities:
   - uid: 350
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,-6.5
-      parent: 1
+      pos: -3.5,-6.5
+      parent: 2
   - uid: 351
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-6.5
+      parent: 2
+  - uid: 352
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-0.5
-      parent: 1
-  - uid: 352
+      parent: 2
+  - uid: 353
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-0.5
-      parent: 1
-  - uid: 353
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,2.5
-      parent: 1
+      parent: 2
   - uid: 354
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,2.5
-      parent: 1
-- proto: RailingCorner
-  entities:
+      pos: -2.5,2.5
+      parent: 2
   - uid: 355
     components:
     - type: Transform
-      pos: 7.5,-6.5
-      parent: 1
+      rot: 3.141592653589793 rad
+      pos: 3.5,2.5
+      parent: 2
+- proto: RailingCorner
+  entities:
   - uid: 356
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 2
+  - uid: 357
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-6.5
-      parent: 1
-  - uid: 357
+      parent: 2
+  - uid: 358
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-5.5
-      parent: 1
-  - uid: 358
+      parent: 2
+  - uid: 359
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-5.5
-      parent: 1
-  - uid: 359
+      parent: 2
+  - uid: 360
     components:
     - type: Transform
       pos: 1.5,1.5
-      parent: 1
-  - uid: 360
+      parent: 2
+  - uid: 361
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,1.5
-      parent: 1
+      parent: 2
 - proto: RailingCornerSmall
   entities:
-  - uid: 361
+  - uid: 362
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,2.5
-      parent: 1
-  - uid: 362
+      parent: 2
+  - uid: 363
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,2.5
-      parent: 1
+      parent: 2
 - proto: RailingRound
   entities:
-  - uid: 363
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,1.5
-      parent: 1
   - uid: 364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,1.5
-      parent: 1
-- proto: RubberStampClown
-  entities:
-  - uid: 127
+      pos: -4.5,1.5
+      parent: 2
+  - uid: 365
     components:
     - type: Transform
-      parent: 124
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
+      parent: 2
+- proto: RubberStampClown
+  entities:
+  - uid: 128
+    components:
+    - type: Transform
+      parent: 125
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: SpawnClownSpider
   entities:
-  - uid: 365
-    components:
-    - type: Transform
-      pos: -4.5,-4.5
-      parent: 1
   - uid: 366
     components:
     - type: Transform
-      pos: -2.5,-5.5
-      parent: 1
+      pos: -4.5,-4.5
+      parent: 2
   - uid: 367
     components:
     - type: Transform
-      pos: -3.5,-6.5
-      parent: 1
-- proto: SpiderWebClown
-  entities:
+      pos: -2.5,-5.5
+      parent: 2
   - uid: 368
     components:
     - type: Transform
-      pos: -4.5,-6.5
-      parent: 1
+      pos: -3.5,-6.5
+      parent: 2
+- proto: SpiderWebClown
+  entities:
   - uid: 369
     components:
     - type: Transform
-      pos: -2.5,-4.5
-      parent: 1
+      pos: -4.5,-6.5
+      parent: 2
   - uid: 370
     components:
     - type: Transform
-      pos: -2.5,-5.5
-      parent: 1
-- proto: StatueBananiumClown
-  entities:
+      pos: -2.5,-4.5
+      parent: 2
   - uid: 371
     components:
     - type: Transform
-      pos: -5.5,-0.5
-      parent: 1
-- proto: SubstationWallBasic
+      pos: -2.5,-5.5
+      parent: 2
+- proto: StatueBananiumClown
   entities:
   - uid: 372
     components:
     - type: Transform
+      pos: -5.5,-0.5
+      parent: 2
+- proto: SubstationWallBasic
+  entities:
+  - uid: 373
+    components:
+    - type: Transform
       pos: -0.5,-3.5
-      parent: 1
+      parent: 2
 - proto: SuitStorageBase
   entities:
-  - uid: 118
+  - uid: 119
     components:
     - type: Transform
       pos: -3.5,-2.5
-      parent: 1
+      parent: 2
     - type: Lock
       locked: False
     - type: EntityStorage
@@ -2936,16 +2968,16 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 123
-          - 119
-          - 122
+          - 124
           - 120
+          - 123
           - 121
-  - uid: 124
+          - 122
+  - uid: 125
     components:
     - type: Transform
       pos: -5.5,-2.5
-      parent: 1
+      parent: 2
     - type: Lock
       locked: False
     - type: ContainerContainer
@@ -2954,14 +2986,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 126
-          - 125
           - 127
-  - uid: 128
+          - 126
+          - 128
+  - uid: 129
     components:
     - type: Transform
       pos: -4.5,-2.5
-      parent: 1
+      parent: 2
     - type: Lock
       locked: False
     - type: ContainerContainer
@@ -2970,424 +3002,424 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 129
           - 130
           - 131
+          - 132
 - proto: TablePlasmaGlass
   entities:
-  - uid: 373
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,1.5
-      parent: 1
   - uid: 374
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,1.5
-      parent: 1
+      pos: 2.5,1.5
+      parent: 2
   - uid: 375
     components:
     - type: Transform
-      pos: -1.5,0.5
-      parent: 1
+      rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 2
   - uid: 376
     components:
     - type: Transform
-      pos: 2.5,0.5
-      parent: 1
-- proto: Thruster
-  entities:
+      pos: -1.5,0.5
+      parent: 2
   - uid: 377
     components:
     - type: Transform
-      pos: 4.5,1.5
-      parent: 1
+      pos: 2.5,0.5
+      parent: 2
+- proto: Thruster
+  entities:
   - uid: 378
     components:
     - type: Transform
-      pos: -3.5,1.5
-      parent: 1
+      pos: 4.5,1.5
+      parent: 2
   - uid: 379
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 2
+  - uid: 380
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-4.5
-      parent: 1
-  - uid: 380
+      parent: 2
+  - uid: 381
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-4.5
-      parent: 1
-  - uid: 381
+      parent: 2
+  - uid: 382
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-8.5
-      parent: 1
-  - uid: 382
+      parent: 2
+  - uid: 383
     components:
     - type: Transform
       rot: -3.141592653589793 rad
       pos: -2.5,-8.5
-      parent: 1
-  - uid: 383
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-8.5
-      parent: 1
+      parent: 2
   - uid: 384
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,-8.5
-      parent: 1
-- proto: ToolboxMechanicalFilled
-  entities:
-  - uid: 27
+      pos: -4.5,-8.5
+      parent: 2
+  - uid: 385
     components:
     - type: Transform
-      parent: 23
+      rot: 3.141592653589793 rad
+      pos: 5.5,-8.5
+      parent: 2
+- proto: ToolboxMechanicalFilled
+  entities:
+  - uid: 28
+    components:
+    - type: Transform
+      parent: 24
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 32
+  - uid: 33
     components:
     - type: Transform
-      parent: 28
+      parent: 29
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 385
-    components:
-    - type: Transform
-      pos: -3.5,-0.5
-      parent: 1
-- proto: VisitorClownSpawner
-  entities:
   - uid: 386
     components:
     - type: Transform
-      pos: 3.5,-6.5
-      parent: 1
+      pos: -3.5,-0.5
+      parent: 2
+- proto: VisitorClownSpawner
+  entities:
   - uid: 387
     components:
     - type: Transform
-      pos: 5.5,-4.5
-      parent: 1
+      pos: 3.5,-6.5
+      parent: 2
   - uid: 388
     components:
     - type: Transform
-      pos: 5.5,-6.5
-      parent: 1
-- proto: WallClown
-  entities:
+      pos: 5.5,-4.5
+      parent: 2
   - uid: 389
     components:
     - type: Transform
-      pos: 4.5,-8.5
-      parent: 1
+      pos: 5.5,-6.5
+      parent: 2
+- proto: WallClown
+  entities:
   - uid: 390
     components:
     - type: Transform
-      pos: -3.5,-8.5
-      parent: 1
+      pos: 4.5,-8.5
+      parent: 2
   - uid: 391
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,0.5
-      parent: 1
+      pos: -3.5,-8.5
+      parent: 2
   - uid: 392
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,0.5
-      parent: 1
+      pos: 5.5,0.5
+      parent: 2
   - uid: 393
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 2
+  - uid: 394
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-4.5
-      parent: 1
-  - uid: 394
+      parent: 2
+  - uid: 395
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,0.5
-      parent: 1
-  - uid: 395
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-7.5
-      parent: 1
+      parent: 2
   - uid: 396
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-7.5
-      parent: 1
+      pos: 6.5,-7.5
+      parent: 2
   - uid: 397
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-4.5
-      parent: 1
+      pos: -5.5,-7.5
+      parent: 2
   - uid: 398
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,0.5
-      parent: 1
+      rot: 3.141592653589793 rad
+      pos: -5.5,-4.5
+      parent: 2
   - uid: 399
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -6.5,-3.5
-      parent: 1
+      pos: -3.5,0.5
+      parent: 2
   - uid: 400
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 7.5,-0.5
-      parent: 1
+      pos: -6.5,-3.5
+      parent: 2
   - uid: 401
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 7.5,-1.5
-      parent: 1
+      pos: 7.5,-0.5
+      parent: 2
   - uid: 402
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 7.5,-2.5
-      parent: 1
+      pos: 7.5,-1.5
+      parent: 2
   - uid: 403
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 7.5,-3.5
-      parent: 1
+      pos: 7.5,-2.5
+      parent: 2
   - uid: 404
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,-3.5
-      parent: 1
+      pos: 7.5,-3.5
+      parent: 2
   - uid: 405
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -5.5,-3.5
-      parent: 1
+      pos: 6.5,-3.5
+      parent: 2
   - uid: 406
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-7.5
-      parent: 1
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 2
   - uid: 407
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -3.5,-7.5
-      parent: 1
+      pos: -4.5,-7.5
+      parent: 2
   - uid: 408
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.5,-7.5
-      parent: 1
+      pos: -3.5,-7.5
+      parent: 2
   - uid: 409
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -1.5,-7.5
-      parent: 1
+      pos: -2.5,-7.5
+      parent: 2
   - uid: 410
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 5.5,-7.5
-      parent: 1
+      pos: -1.5,-7.5
+      parent: 2
   - uid: 411
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 4.5,-7.5
-      parent: 1
+      pos: 5.5,-7.5
+      parent: 2
   - uid: 412
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,-7.5
-      parent: 1
+      pos: 4.5,-7.5
+      parent: 2
   - uid: 413
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,-7.5
-      parent: 1
+      pos: 3.5,-7.5
+      parent: 2
   - uid: 414
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,-6.5
-      parent: 1
+      pos: 2.5,-7.5
+      parent: 2
   - uid: 415
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,-4.5
-      parent: 1
+      pos: 2.5,-6.5
+      parent: 2
   - uid: 416
     components:
     - type: Transform
-      pos: -0.5,-3.5
-      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 2
   - uid: 417
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-3.5
-      parent: 1
+      pos: -0.5,-3.5
+      parent: 2
   - uid: 418
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.5,-3.5
-      parent: 1
+      pos: -1.5,-3.5
+      parent: 2
   - uid: 419
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -3.5,-3.5
-      parent: 1
+      pos: -2.5,-3.5
+      parent: 2
   - uid: 420
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -4.5,-3.5
-      parent: 1
+      pos: -3.5,-3.5
+      parent: 2
   - uid: 421
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.5,-2.5
-      parent: 1
+      pos: -4.5,-3.5
+      parent: 2
   - uid: 422
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,-3.5
-      parent: 1
+      pos: -2.5,-2.5
+      parent: 2
   - uid: 423
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,-3.5
-      parent: 1
+      pos: 1.5,-3.5
+      parent: 2
   - uid: 424
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,-3.5
-      parent: 1
+      pos: 2.5,-3.5
+      parent: 2
   - uid: 425
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 4.5,-3.5
-      parent: 1
+      pos: 3.5,-3.5
+      parent: 2
   - uid: 426
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 5.5,-3.5
-      parent: 1
+      pos: 4.5,-3.5
+      parent: 2
   - uid: 427
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,-0.5
-      parent: 1
+      pos: 5.5,-3.5
+      parent: 2
   - uid: 428
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,0.5
-      parent: 1
+      pos: 3.5,-0.5
+      parent: 2
   - uid: 429
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,1.5
-      parent: 1
+      pos: 3.5,0.5
+      parent: 2
   - uid: 430
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.5,-0.5
-      parent: 1
+      pos: 3.5,1.5
+      parent: 2
   - uid: 431
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.5,0.5
-      parent: 1
+      pos: -2.5,-0.5
+      parent: 2
   - uid: 432
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.5,1.5
-      parent: 1
+      pos: -2.5,0.5
+      parent: 2
   - uid: 433
     components:
     - type: Transform
-      pos: -1.5,-8.5
-      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 2
   - uid: 434
     components:
     - type: Transform
-      pos: -0.5,-8.5
-      parent: 1
+      pos: -1.5,-8.5
+      parent: 2
   - uid: 435
     components:
     - type: Transform
-      pos: 0.5,-8.5
-      parent: 1
+      pos: -0.5,-8.5
+      parent: 2
   - uid: 436
     components:
     - type: Transform
-      pos: 1.5,-8.5
-      parent: 1
+      pos: 0.5,-8.5
+      parent: 2
   - uid: 437
     components:
     - type: Transform
-      pos: 2.5,-8.5
-      parent: 1
+      pos: 1.5,-8.5
+      parent: 2
   - uid: 438
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-0.5
-      parent: 1
+      pos: 2.5,-8.5
+      parent: 2
   - uid: 439
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -6.5,-2.5
-      parent: 1
+      pos: -6.5,-0.5
+      parent: 2
   - uid: 440
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-2.5
+      parent: 2
+  - uid: 441
+    components:
+    - type: Transform
       pos: 3.5,-2.5
-      parent: 1
+      parent: 2
 ...


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Небольшой ПР по трекеру на добавление клоунского аплинка на шаттл гостовых клоунов. Добавлено исключительно для разнообразия предоставления веселья довольно ограниченных клоунов. В аплинке сразу есть 100 кожурок для начального веселья


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->


:cl:
- add: Клоунам-потеряшкам добавлен клоунский аплинк для улучшенного веселья!
- fix: Исправление атмоса на шаттле потерянных клоунов в спальне. Теперь там никто не будет задыхаться (Кроме воксов)