### PR TITLE
Dec outer clothing rebalance 

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/coats.yml
@@ -34,7 +34,7 @@
         coefficients:
           Blunt: 0.8
           Slash: 0.8
-          Piercing: 0.6
+          Piercing: 0.7 #SS220 detective outer rebalance
           Heat: 0.9
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -114,7 +114,7 @@
 
 #Detective's vest
 - type: entity
-  parent: [ClothingOuterArmorBase, BaseSecurityContraband, ClothingOuterStorageBase]
+  parent: [ClothingOuterArmorBase, BaseSecurityContraband, ClothingOuterStorageBase] #SS220 detective outer rebalance
   id: ClothingOuterVestDetective
   name: detective's vest
   description: A hard-boiled private investigator's armored vest.
@@ -128,6 +128,11 @@
     grid:
     - 0,0,0,1
     - 2,0,2,1
+  - type: ContainerContainer
+    containers:
+      storagebase: !type:Container
+        ents: []
+      item_radio: !type:ContainerSlot #ss220 handheld radio on outer clothing
 #SS220 detective outer rebalance end
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -114,7 +114,7 @@
 
 #Detective's vest
 - type: entity
-  parent: [ClothingOuterArmorBase, BaseSecurityContraband]
+  parent: [ClothingOuterArmorBase, BaseSecurityContraband, ClothingOuterStorageBase]
   id: ClothingOuterVestDetective
   name: detective's vest
   description: A hard-boiled private investigator's armored vest.
@@ -123,6 +123,12 @@
     sprite: Clothing/OuterClothing/Vests/detvest.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Vests/detvest.rsi
+#SS220 detective outer rebalance begin
+  - type: Storage
+    grid:
+    - 0,0,0,1
+    - 2,0,2,1
+#SS220 detective outer rebalance end
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -32,7 +32,7 @@
       coefficients:
         Blunt: 0.70
         Slash: 0.70
-        Piercing: 0.70
+        Piercing: 0.80 #SS220 detective outer rebalance
         Heat: 0.80
   - type: ExplosionResistance
     damageCoefficient: 1 #its a coat. it doesnt do shit


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
ПР по одобренной идее https://github.com/SerbiaStrong-220/DevTeam220/issues/474.
Снижение резиста к колющему всех пальто дека на 10 процентов и добавление двух карманов по два слота бронежилету детектива


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->


:cl:
- tweak: Изменена верхняя одежда детектива. Все пальто детектива теперь имеют на 10% меньшую защиту от колющего урона; Бронежилет детектива теперь имеет два кармана по 2 клетки
-->
