### PR TITLE
Revive Juggernaut Suit

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -867,7 +867,7 @@
         Blunt: 0.2
         Slash: 0.2
         Piercing: 0.2
-        Heat: 0.4 #ss-220 armReb
+        Heat: 0.2
         Radiation: 0.2
         Caustic: 0.2
   # SS220 add stamina resistance begin


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Трекер: https://discord.com/channels/1097181193939730453/1419367001096458300

Откат части баланса Зонеса относительно рига Джаггернаута:
> `tweak: Риг Джаггернаута больше не горит, но получает больше урона от лазеров.`

Для баланса "негорения" была снижена защита от `heat` на 20%. На первый взгляд это выглядит несущественно, но при расчётах (_если они у меня верные_) выходит, что выживаемость от `heat` падает почти в два раза (с 25 выстрелов до 13).

При этом Джаггернаут всё же продолжает гореть - получает ~22% урона от горения.

В итоге уменьшение урона от горения до ~22% не оправдывает того факта, что лазеры пробивают в два раза сильнее. Всё же основное оружие НТ - это именно лазеры

Снижение урона от горения оставлено на уровне ~22%. Всё же это Джаггернаут, да и в своём балансе Зонес сильно баффнул другие скафандры.

**Медиа**
<img width="1241" height="187" alt="image" src="https://github.com/user-attachments/assets/4e29d589-6756-40ac-aff8-0f8618e9f0f1" />

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl: Kemran
- tweak: Изменен резист к ожогам скафандра Джаггернаута с 60% до 80% (с 13 выстрелов до 25).
