### PR TITLE
FIX: Medibot inject by damage groups

### DIFF
--- a/Content.Shared/Silicons/Bots/MedibotSystem.cs
+++ b/Content.Shared/Silicons/Bots/MedibotSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Popups;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Serialization;
 using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.Prototypes; //ss220 fix medibot
 
 namespace Content.Shared.Silicons.Bots;
 
@@ -25,6 +26,7 @@ public sealed class MedibotSystem : EntitySystem
     [Dependency] private SharedSolutionContainerSystem _solutionContainer = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!; //ss220 fix medibot
 
     public override void Initialize()
     {
@@ -108,13 +110,16 @@ public sealed class MedibotSystem : EntitySystem
         }
 
         var total = damageable.TotalDamage;
-        if (total == 0 && !HasComp<EmaggedComponent>(medibot))
+        //ss220 fix medibot start
+        var isEmagged = HasComp<EmaggedComponent>(medibot);
+        if (total == 0 && !isEmagged)
         {
             _popup.PopupClient(Loc.GetString("medibot-target-healthy"), medibot, medibot);
             return false;
         }
 
-        if (!TryGetTreatment(medibot.Comp, mobState.CurrentState, out var treatment) || !treatment.IsValid(total) && !manual) return false;
+        if (!TryGetTreatment(medibot.Comp, mobState.CurrentState, out var treatment) || !treatment.IsValid(damageable.Damage, isEmagged, _proto) && !manual) return false;
+        //ss220 fix medibot end
 
         return true;
     }


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Медибот теперь будет инжектить реагенты, только если присутствует определенный вид хил-урона в этом реагенте.
Так же исправил баг, когда медибот никого не инжектил когда был емагнутым, ибо была проверка на другие ентити, а не на медибота

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl: ReeZii
- add: Медибот теперь не будет вкалывать препараты, если он не может вылечить тип урона у игрока
