### PR TITLE
New TTS cccvars for ent queue

### DIFF
--- a/Content.Client/SS220/TTS/TTSSystem.cs
+++ b/Content.Client/SS220/TTS/TTSSystem.cs
@@ -2,6 +2,7 @@
 
 using System.IO;
 using Content.Shared.Corvax.CCCVars;
+using Content.Shared.SS220.CCVars;
 using Content.Shared.SS220.TTS;
 using Content.Shared.SS220.TTS.Commands;
 using Robust.Client.Audio;
@@ -35,8 +36,8 @@ public sealed partial class TTSSystem
     private float _volume = 0.0f;
     private float _radioVolume = 0.0f;
 
-    private const int MaxQueuedPerEntity = 20;
-    private const int MaxEntitiesQueued = 30;
+    private readonly int _maxQueuedPerEntity = 20;
+    private readonly int _maxEntitiesQueued = 30;
     private readonly Dictionary<EntityUid, Queue<PlayRequest>> _playQueues = new();
     private readonly Dictionary<EntityUid, EntityUid?> _playingStreams = new();
 
@@ -46,6 +47,8 @@ public sealed partial class TTSSystem
     {
         _sawmill = Logger.GetSawmill("tts");
 
+        Subs.CVar(_config, CCVars220.MaxQueuedPerEntity, (x) => _maxQueuedPerEntity = x, true);
+        Subs.CVar(_config, CCVars220.MaxEntitiesQueued, (x) => _maxEntitiesQueued = x, true);
         _cfg.OnValueChanged(CCCVars.TTSVolume, OnTtsVolumeChanged, true);
         _cfg.OnValueChanged(CCCVars.TTSRadioVolume, OnTtsRadioVolumeChanged, true);
 
@@ -173,14 +176,14 @@ public sealed partial class TTSSystem
     {
         if (!_playQueues.TryGetValue(entity, out var queue))
         {
-            if (_playQueues.Count >= MaxEntitiesQueued)
+            if (_playQueues.Count >= _maxEntitiesQueued)
                 return;
 
             queue = new();
             _playQueues.Add(entity, queue);
         }
 
-        if (queue.Count >= MaxQueuedPerEntity)
+        if (queue.Count >= _maxQueuedPerEntity)
             return;
 
         queue.Enqueue(request);

--- a/Content.Shared/SS220/CCVars/CCVars220.cs
+++ b/Content.Shared/SS220/CCVars/CCVars220.cs
@@ -136,4 +136,14 @@ public sealed partial class CCVars220
     /// </summary>
     public static readonly CVarDef<string> AdditionalBanInfo =
         CVarDef.Create("ban.additional_info", "", CVar.SERVERONLY | CVar.ARCHIVE);
+    /// <summary>
+    /// Maximum entity capacity for tts queue
+    /// </summary>
+    public static readonly CVarDef<string> MaxQueuedPerEntity =
+        CVarDef.Create("tts.max_queued_entity", 20, CVar.CLIENTONLY | CVar.ARCHIVE);
+    /// <summary>
+    /// Maximum of queued tts entities
+    /// </summary>
+    public static readonly CVarDef<string> MaxEntitiesQueued =
+        CVarDef.Create("tts.max_entities_queued", 30, CVar.CLIENTONLY | CVar.ARCHIVE);
 }


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Знаете, когда делаете что-то, не понимая что-то делаете. Так вот, литерали я.
Для тестирования поведения TTS в высокой нагрузке хайпопа, добавляю два клиентских сивара на настройку очереди ентитей. Вторым этапом буду делать доп. настройки в меню, но только после тестирований, сначала нужно определить надобность.
Затрагивает: https://github.com/SerbiaStrong-220/space-station-14/issues/2425

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

no cl no fun
