### PR TITLE
Tweak layers of belts

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -116,9 +116,9 @@
       - map: ["enum.HumanoidVisualLayers.RHand"]
       - map: [ "gloves" ]
       - map: [ "shoes" ]
+      - map: [ "outerClothing" ] #SS220 tweak layers of belts
+      - map: [ "belt" ]
       - map: [ "id" ]
-      - map: [ "outerClothing" ]
-      - map: [ "belt" ] #SS220 fix layers of belts
       - map: [ "enum.HumanoidVisualLayers.Tail" ] # Mentioned in moth code: This needs renaming lol.
       - map: [ "back" ]
       - map: [ "neck" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -30,9 +30,9 @@
     - map: [ "shoes" ]
     - map: [ "ears" ]
     - map: [ "eyes" ]
+    - map: [ "outerClothing" ] #SS220 tweak layers of belts
+    - map: [ "belt" ]
     - map: [ "id" ]
-    - map: [ "outerClothing" ]
-    - map: [ "belt" ] #SS220 fix layers of belts
     - map: [ "back" ]
     - map: [ "neck" ]
     - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
@@ -327,9 +327,9 @@
     - map: [ "shoes" ]
     - map: [ "ears" ]
     - map: [ "eyes" ]
+    - map: [ "outerClothing" ] #SS220 tweak layers of belts
+    - map: [ "belt" ]
     - map: [ "id" ]
-    - map: [ "outerClothing" ]
-    - map: [ "belt" ] #SS220 fix layers of belts
     - map: [ "back" ]
     - map: [ "neck" ]
     - map: [ "enum.HumanoidVisualLayers.FacialHair" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -124,9 +124,9 @@
       - map: [ "shoes" ]
       - map: [ "ears" ]
       - map: [ "eyes" ]
+      - map: [ "outerClothing" ] #SS220 tweak layers of belts
+      - map: [ "belt" ]
       - map: [ "id" ]
-      - map: [ "outerClothing" ]
-      - map: [ "belt" ] #SS220 fix layers of belts
       - map: [ "enum.HumanoidVisualLayers.Tail" ] #in the utopian future we should probably have a wings enum inserted here so everyhting doesn't break
       - map: [ "back" ]
       - map: [ "neck" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -101,9 +101,9 @@
     - map: [ "ears" ]
     - map: [ "enum.HumanoidVisualLayers.Snout" ] #SS220-Vox Beak
     - map: [ "eyes" ]
+    - map: [ "outerClothing" ] #SS220 tweak layers of belts
+    - map: [ "belt" ]
     - map: [ "id" ]
-    - map: [ "outerClothing" ]
-    - map: [ "belt" ] #SS220 fix layers of belts
     - map: [ "back" ]
     - map: [ "neck" ]
     - map: [ "suitstorage" ] # This is not in the default order


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Данный ПР ставит слот пояса выше слота верхней одежды. 
По результатам опроса в трекерах SS220, было выявлено, что большая часть игроков (73%) хотят вернуть наложение поясов поверх верхней одежды. 

 Сам трекер: https://discord.com/channels/1097181193939730453/1420019347342098432

По хорошему, надо сделать возможность переключения слоя у поясов. Но у меня мозгов на это не хватает, так что просто возвращаю старое наложение 

**Медиа**

![1482520_268](https://github.com/user-attachments/assets/6b95e65a-2cf8-42cf-aef4-dbef2a90ef91)


<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl:
- tweak: Пояса теперь отображаются поверх верхней одежды

