### PR TITLE
FIX: CigPack whitelist storage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -122,6 +122,13 @@
     shape: # Yes, this is cursed, but it breaks otherwise, dont question it.
     - 0,0,0,1
   - type: Storage
+    # SS220 cigarette pack fix start
+    whitelist:
+      tags:
+      - Cigarette
+      - Lighter
+      - Cigar
+    # SS220 cigarette pack fix end
     grid:
     - 0,0,4,1
   - type: ItemCounter

--- a/Resources/Prototypes/SS220/Entities/Objects/Consumable/Smokeables/case.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Consumable/Smokeables/case.yml
@@ -29,6 +29,12 @@
       map: ["snuff6"]
       visible: false
   - type: Storage
+    whitelist:
+      tags:
+      - Smokable
+      - Cigarette
+      - Cigar
+      - Lighter
     grid:
     - 0,0,2,1
   - type: Item


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Пофикшен вайтлист сигаретных паков, в которые влазило многое
(fix: https://github.com/SerbiaStrong-220/space-station-14/issues/3420)

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

no cl no fun
