### PR TITLE
ADD: Visibility phrase only for recorder

### DIFF
--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnVoiceComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnVoiceComponent.cs
@@ -92,4 +92,12 @@ public sealed partial class TriggerOnVoiceComponent : BaseTriggerOnXComponent
     /// </summary>
     [DataField]
     public LocId? InspectInitializedLoc = "trigger-on-voice-examine";
+
+    // ss220 add visibility only for recorder start
+    [DataField]
+    public bool IsVisibleOnlyToRecorder;
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? Recorder;
+    // ss220 add visibility only for recorder end
 }

--- a/Content.Shared/Trigger/Systems/TriggerSystem.Voice.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.Voice.cs
@@ -30,6 +30,11 @@ public sealed partial class TriggerSystem
         if (!args.IsInDetailsRange || !component.ShowExamine)
             return;
 
+        // ss220 add visibility only to recorder start
+        if (component is { IsVisibleOnlyToRecorder: true, Recorder: not null } && component.Recorder.Value != args.Examiner)
+            return;
+        // ss220 add visibility only to recorder end
+
         if (component.InspectUninitializedLoc != null && string.IsNullOrWhiteSpace(component.KeyPhrase))
         {
             args.PushText(Loc.GetString(component.InspectUninitializedLoc));
@@ -145,6 +150,9 @@ public sealed partial class TriggerSystem
     {
         ent.Comp.KeyPhrase = message;
         ent.Comp.IsRecording = false;
+        //ss220 add visibility only to recorder start
+        ent.Comp.Recorder = source;
+        //ss220 add visibility only to recorder end
         Dirty(ent);
 
         _adminLogger.Add(LogType.Trigger, LogImpact.Low,

--- a/Resources/Prototypes/Entities/Objects/Specific/locks.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/locks.yml
@@ -19,6 +19,7 @@
     recordingVerbMessage: voice-trigger-lock-verb-message
     inspectUninitializedLoc: voice-trigger-lock-on-uninitialized
     inspectInitializedLoc: voice-trigger-lock-on-examine
+    isVisibleOnlyToRecorder: true #ss220 add visibility only for recorder
   - type: LockOnTrigger
   - type: ActiveListener
   - type: VoiceTriggerLock


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Теперь фразы у хамелеона отображаются только для того, кто их записал.
(fix: https://github.com/SerbiaStrong-220/space-station-14/issues/3413)

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl: ReeZii
- add: Теперь код-фразы на хамелеоне видит только его владелец
