### PR TITLE
Trashbag fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
@@ -22,6 +22,8 @@
       tags:
         - Cartridge
         - Trash
+        - Grenade
+        - ToyGrenade
   - type: UseDelay
     delay: 0.5
   - type: Tag

--- a/Resources/Prototypes/SS220/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/toy.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/toy.yml
@@ -8,6 +8,7 @@
   - type: Tag
     tags:
     - ShellShotgunToy
+    - Cartridge
   - type: HiddenDescription
     entries:
     - label: hidden-desc-toy-weapons-ammo-syndicate
@@ -94,6 +95,7 @@
   - type: Tag
     tags:
     - CartridgeAntiMaterielToy
+    - Cartridge
   - type: HiddenDescription
     entries:
     - label: hidden-desc-toy-weapons-ammo-syndicate


### PR DESCRIPTION
## Описание PR
По исшую: https://github.com/SerbiaStrong-220/space-station-14/issues/3448
Теперь ВСЕ игрушечные гильзы лезут в мешок для мусора. Гильзы чайны тоже.

**Медиа**


<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl:
- fix: В мешок для мусора можно сложить гильзы игрушечного христова, чайны и бульдога
