### PR TITLE
FIX: Visible cooldown on Dragon Breath Gun

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/ActionGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/ActionGunSystem.cs
@@ -34,7 +34,7 @@ public sealed class ActionGunSystem : EntitySystem
 
     private void OnShoot(Entity<ActionGunComponent> ent, ref ActionGunShootEvent args)
     {
-        // ss220 fix visible cooldown on dragon breath gun start
+        // SS220-MIT fix visible cooldown on dragon breath gun start
         if (!TryComp<GunComponent>(ent.Comp.Gun, out var gun) || ent.Comp.ActionEntity == null)
             return;
 
@@ -45,7 +45,7 @@ public sealed class ActionGunSystem : EntitySystem
             return;
 
         _actions.SetCooldown(args.Action.Owner, TimeSpan.FromSeconds(recharge.RechargeCooldown));
-        // ss220 fix visible cooldown on dragon breath gun end
+        // SS220-MIT fix visible cooldown on dragon breath gun end
     }
 }
 


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
У дракона не было видимой перезарядки у экшена.
(fix: https://github.com/SerbiaStrong-220/space-station-14/issues/3591)

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
no cl
