### PR TITLE
BananaPieNerf

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
@@ -16,7 +16,7 @@
   - FoodPlatePlastic
   - FoodPlateSmallPlastic
   - FoodBowlBig
-  - FoodPlateTin
+  #- FoodPlateTin SS220 BananaPieNerf
   - FoodPlateMuffinTin
   - FoodKebabSkewer
   - SprayBottle


### PR DESCRIPTION
## Описание PR
 - Убрал из автолата рецепт "Формочка для пирога" по причине лёгкого создания банановых пирогов и спама пирогами экипажем против ядерных оперативников. В посудомате и так есть 5 формочек и существует его пополнение дающее 5 доп. из за чего апдейт никак не повлияет на мирную часть этих пирогов.

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
- remove: Убран рецепт "Формочка для пирога из автолата"

:cl: Hvoev