### PR TITLE
Fix scram implant

### DIFF
--- a/Content.Shared/Trigger/Systems/ScramOnTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/ScramOnTriggerSystem.cs
@@ -103,7 +103,7 @@ public sealed class ScramOnTriggerSystem : EntitySystem
         {
             var valid = false;
 
-            var range = (float)Math.Sqrt(radius);
+            var range = radius; // SS220-FixScramTeleportRadius
             var box = Box2.CenteredAround(userCoords.Position, new Vector2(range, range));
             var tilesInRange = _map.GetTilesEnumerator(targetGrid.Value.Owner, targetGrid.Value.Comp, box, false);
             var tileList = new ValueList<Vector2i>();

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -186,7 +186,7 @@
   #SS220-underused-uplinks-stuff end
   components:
   - type: LimitedCharges
-    maxCharges: 12 #SS220 changed
+    maxCharges: 2 #SS220 changed
   - type: Action
     checkCanInteract: false
     useDelay: 5


### PR DESCRIPTION
## Описание PR

Исправление логики скрам-импланта.

Раньше он по приколу брал квадратный корень радиуса, а не требуемый радиус, от чего получался фактический радиус не 100, а 10.

Количество зарядов возвращено на 2.

Баунти: https://github.com/SerbiaStrong-220/DevTeam220/issues/599


**Медиа**

https://github.com/user-attachments/assets/91630d75-9cd6-415f-9e9b-58a3aac6f52a

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl:
- tweak: Скрам имплант теперь имеет только 2 заряда
- fix: Исправлен радиус телепортации скрам-импланта, теперь он составляет 100 тайлов
