### PR TITLE
Fixing mouse pathing under reinforced tables

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
@@ -77,7 +77,7 @@
         mask:
         - TableMask
         layer:
-        - CounterLayer
+        - TableLayer
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Wood
@@ -201,7 +201,7 @@
 
 - type: entity
   id: TableReinforced
-  parent: CounterBase
+  parent: TableBase
   name: reinforced table
   description: A square piece of metal standing on four metal legs. Extra robust.
   components:
@@ -471,7 +471,7 @@
 
 - type: entity
   id: TableBrass
-  parent: CounterBase
+  parent: TableBase
   name: brass table
   description: A shiny, corrosion resistant brass table. Steampunk!
   components:
@@ -615,7 +615,7 @@
 
 - type: entity
   id: TableStone
-  parent: CounterBase
+  parent: TableBase
   name: stone table
   description: Literally the sturdiest thing you have ever seen.
   components:
@@ -675,7 +675,7 @@
       collection: FootstepCarpet
 
 - type: entity
-  parent: CounterBase
+  parent: TableBase
   id: TableXeno
   name: xeno table
   description: I wouldn't put the silverware on it.
@@ -900,9 +900,6 @@
   description: PUT ON THEM CODERSOCKS!!
   suffix: DEBUG
   components:
-  - type: Tag
-    tags:
-      - Debug
   - type: Sprite
     sprite: Structures/Furniture/Tables/debug.rsi
   - type: Icon


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Актуализирует файл `tables.yml` по пути `Resources\Prototypes\Entities\Structures\Furniture\Tables` до версии Визденов. 

 Исправляет баг: https://discord.com/channels/1097181193939730453/1439915460513763328
<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl: Kemran
- fix: Теперь мыши могут проходить под укреплёнными столами.
