### PR TITLE
FIX: Emergency shutle vote when shuttle arrived

### DIFF
--- a/Content.Server/SS220/GameTicking/Rules/EmergencyShuttleAutoVoteRuleSystem.cs
+++ b/Content.Server/SS220/GameTicking/Rules/EmergencyShuttleAutoVoteRuleSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Administration.Logs;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
 using Content.Server.RoundEnd;
+using Content.Server.Shuttles.Systems;
 using Content.Server.SS220.GameTicking.Rules.Components;
 using Content.Server.Voting;
 using Content.Server.Voting.Managers;
@@ -21,6 +22,7 @@ public sealed class EmergencyShuttleAutoVoteRuleSystem : GameRuleSystem<Emergenc
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly RoundEndSystem _roundEnd = default!;
     [Dependency] private readonly IVoteManager _voteManager = default!;
+    [Dependency] private readonly EmergencyShuttleSystem _emergencyShuttle = default!;
 
     private TimeSpan RoundTime => _gameTiming.CurTime - _gameTicker.RoundStartTimeSpan;
 
@@ -50,6 +52,12 @@ public sealed class EmergencyShuttleAutoVoteRuleSystem : GameRuleSystem<Emergenc
 
         if (RoundTime < component.LastEvacVoteTime + component.IntervalBetweenVotes)
             return;
+
+        if (_emergencyShuttle.EmergencyShuttleArrived)
+        {
+            _gameTicker.EndGameRule(uid, gameRule);
+            return;
+        }
 
         MakeEmergencyShuttleVote(component);
     }


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
(fix: https://github.com/SerbiaStrong-220/space-station-14/issues/3653)
Теперь не будет голосования за вызов шаттла, если он уже пристыкован, летит на цк, или пристыковался на цк.

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
no cl no fun