### PR TITLE
Fix botany phalanximine

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -588,11 +588,7 @@
   plantMetabolism:
     - !type:PlantAdjustToxins
       amount: 6
-    - !type:PlantPhalanximine
-      conditions:
-      - !type:ReagentCondition
-        reagent: Phalanximine
-        min: 4
+    - !type:PlantPhalanximine {}
   metabolisms:
     Medicine:
       metabolismRate: 0.1


### PR DESCRIPTION
## Описание PR
По какой-то загадочной причине, при присутствии кондишена для plant metabolism effect, хэндлер эффекта не вызывается.

Убрал кондишнал эффект от фаланги по растениям, у других plant metabolism effect эффектов кондишнов нет, а сам он не отрабатывает по какой-то причине, да и кондишн на 4ед фаланги для лечения рака (имхо) это лишнее.

ref: https://github.com/SerbiaStrong-220/space-station-14/issues/3547

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl: Zarret

- fix: Фалангимин теперь снова лечит рак у растений
