### PR TITLE
Allow reading while handcuffed

### DIFF
--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Components;
 using Content.Shared.Administration.Logs;
@@ -34,7 +35,6 @@ using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
-using System.Linq;
 using PullableComponent = Content.Shared.Movement.Pulling.Components.PullableComponent;
 
 namespace Content.Shared.Cuffs


### PR DESCRIPTION
## Описание PR
Теперь наручники не мешают ознакомиться с ордером в бриге.

В тупую проверяем наличие `PaperComponent` на целевом объекте при попытке взаимодействия.
Как хотфикс пойдёт, PJB говорит будет рефактор interaction system на манер SS13.

**Медиа**
https://github.com/user-attachments/assets/16f02f90-3a81-424e-8fc8-67e746131fd4

<!--CLIgnore-->
**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl:
- fix: Наручники больше не мешают читать
