### PR TITLE
FIX: Stack split amount

### DIFF
--- a/Content.Server/Stack/StackSystem.cs
+++ b/Content.Server/Stack/StackSystem.cs
@@ -164,6 +164,7 @@ namespace Content.Server.Stack
             return amounts;
         }
 
+        // ss220 split fix start // wow, no comments ss220 here...
         protected override AlternativeVerb? MakeCustomVerb(EntityUid user, Entity<StackComponent> stackEntity, LocId title, LocId prompt)
         {
             var customAmount = new AlternativeVerb
@@ -178,9 +179,18 @@ namespace Content.Server.Stack
                     _quickDialog.OpenDialog(actorComp.PlayerSession,
                         Loc.GetString(title),
                         Loc.GetString(prompt),
-                        (int amount) =>
+                        (string amount) =>
                         {
-                            UserSplit(stackEntity.Owner, user, amount, stackEntity.Comp);
+                            if (string.IsNullOrEmpty(amount))
+                                return;
+
+                            if (!int.TryParse(amount, out var amountInt))
+                                return;
+
+                            if (amountInt <= 0)
+                                return;
+
+                            UserSplit(stackEntity.Owner, user, amountInt, stackEntity.Comp);
                         },
                         () =>
                         {
@@ -192,6 +202,7 @@ namespace Content.Server.Stack
 
             return customAmount;
         }
+        // ss220 split fix end
 
         protected override void UserSplit(EntityUid uid, EntityUid userUid, int amount,
             StackComponent? stack = null,


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
(fix: https://discord.com/channels/1097181193939730453/1450124496265543916)

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl: ReeZii
- fix: Некорректный ввод количества для разделения предметов теперь не вызывает краш клиента!