### PR TITLE
ADD: Speed boots rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -138,7 +138,7 @@
   - type: ToggleClothing
     action: ActionToggleSpeedBoots
   - type: ClothingSpeedModifier
-    walkModifier: 1.25
+    walkModifier: 1.25 # SS220 speedboots rebalance
     sprintModifier: 1.25 # SS220 speedboots rebalance
     standing: true
   - type: Appearance


### PR DESCRIPTION
## Описание PR
- Теперь ускорения у скороходов не 50% а 25%
- Теперь скороходы едят заряд с большей задержкой
(fix: https://github.com/SerbiaStrong-220/DevTeam220/issues/666)

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
- tweak: Теперь ускорения у скороходов не 50% а 25%
- tweak: Теперь скороходы едят заряд с большей задержкой