### PR TITLE
ADD: Pen Signaller range

### DIFF
--- a/Resources/Prototypes/SS220/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Misc/pen.yml
@@ -52,7 +52,7 @@
       deviceNetId: Wireless
       receiveFrequencyId: BasicDevice
     - type: WirelessNetworkConnection
-      range: 15
+      range: 60
     - type: Tag
       tags:
         - Write


### PR DESCRIPTION
## Описание PR
- Теперь у ручки-передатчика расстояние 60 тайлов вместо 15
(fix: https://github.com/SerbiaStrong-220/DevTeam220/issues/713)

**Медиа**


<!--CLIgnore-->
**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl: molachucat
- tweak: Теперь у ручки-передатчика расстояние 60 тайлов вместо 15
