### PR TITLE
IK-40 PowerCell Storage Fix

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -153,6 +153,7 @@
         - CartridgeAmmo
       tags:             # SS220 blueshield-whitelist-storage-fix
         - KRSPowerCell  # SS220 blueshield-whitelist-storage-fix
+        - LaserSMGPowerCell # SS220 IK-40 PowerCell-Storage-Fix
 
 - type: entity
   parent: [ClothingBeltStorageBase]

--- a/Resources/Prototypes/Entities/Clothing/Belt/job.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/job.yml
@@ -416,6 +416,7 @@
   - type: Storage
     whitelist:
       tags:
+      - LaserSMGPowerCell # SS220 IK-40 PowerCell-Storage-Fix
       - CigPack
       - Taser
       - SecBeltEquip


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
 - Исправил вайт лист поясов СБ в которые нельзя было положить энергоячейки от новой пушки ИК-40.

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl: Hvoev
- fix: Исправлена вместимость энергоячеек ИК-40 в пояса службы безопасности и кобуру!

