### PR TITLE
FIX: TTS message to disconnected session

### DIFF
--- a/Content.Server/SS220/TTS/TTSSystem.cs
+++ b/Content.Server/SS220/TTS/TTSSystem.cs
@@ -15,6 +15,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using Robust.Shared.Enums;
 
 namespace Content.Server.SS220.TTS;
 
@@ -83,6 +84,9 @@ public sealed partial class TTSSystem : EntitySystem
     private void ServerSendMessage(NetMessage message, ICommonSession recipient)
     {
         if (_sessionsNotToSend.Contains(recipient))
+            return;
+
+        if (recipient.Status == SessionStatus.Disconnected)
             return;
 
         _netManager.ServerSendMessage(message, recipient.Channel);


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Теперь по идее не должно отправлять месседжи про ттс отключенным сессиям.

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
no cl
