### PR TITLE
FIX: Unused ninja objective that cause server error

### DIFF
--- a/Content.Client/SS220/Ninja/Objectives/LeaveNoTrace/LeaveNoTraceSystem.cs
+++ b/Content.Client/SS220/Ninja/Objectives/LeaveNoTrace/LeaveNoTraceSystem.cs
@@ -69,6 +69,9 @@ public sealed class LeaveNoTraceSystem : SharedLeaveNoTraceSystem
         if (_playerManager.LocalEntity != ent.Owner)
             return;
 
+        if (TerminatingOrDeleted(ent.Owner))
+            return;
+
         _overlay.IsReveal = true;
 
         var fadeComponent = EnsureComp<RevealOverlayFadeComponent>(ent.Owner);

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -264,9 +264,11 @@
       components:
       - type: CommsHacker
         threats: NinjaThreats
-    - objective: MassArrestObjective
-      components:
-      - type: CriminalRecordsHacker
+    #ss220 remove unused objective for ninja start
+    # - objective: MassArrestObjective
+    #   components:
+    #   - type: CriminalRecordsHacker
+    #ss220 remove unused objective for ninja end
 
 - type: entity
   parent: [ ClothingHandsGlovesColorBlack]


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Убрал неиспользуемую и закомменченую цель у ниндзи, которая вызывала еррор на сервере.
Так же пофиксил клиентский еррор, который добавлял компонент, когда ентити уже была удалена.

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

no cl
