### PR TITLE
Edited available roundstart job in sec dep

### DIFF
--- a/Resources/Prototypes/SS220/Maps/astro.yml
+++ b/Resources/Prototypes/SS220/Maps/astro.yml
@@ -31,7 +31,7 @@
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
             Detective: [ 1, 1 ]
-            SecurityPilot: [ 1, 1 ]
+            SecurityPilot: [ 1, 2 ]
             SecurityOfficer: [ 4, 5 ]
             SecurityCadet: [ 1, 2 ]
             Brigmedic: [ 1, 1 ]

--- a/Resources/Prototypes/SS220/Maps/axioma.yml
+++ b/Resources/Prototypes/SS220/Maps/axioma.yml
@@ -30,7 +30,7 @@
             Warden: [ 1, 1 ]
             SeniorOfficer: [ 1, 1]
             Detective: [ 1, 1 ]
-            SecurityPilot: [ 1, 1 ]
+            SecurityPilot: [ 1, 2 ]
             SecurityOfficer: [ 4, 5 ]
             SecurityCadet: [ 2, 2 ]
             Brigmedic: [ 1, 1 ]

--- a/Resources/Prototypes/SS220/Maps/donuts.yml
+++ b/Resources/Prototypes/SS220/Maps/donuts.yml
@@ -30,7 +30,7 @@
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
             Detective: [ 1, 1 ]
-            SecurityPilot: [ 1, 1 ]
+            SecurityPilot: [ 1, 2 ]
             SecurityOfficer: [ 3, 4 ]
             SecurityCadet: [ 1, 2 ]
             Brigmedic: [ 1, 1 ]

--- a/Resources/Prototypes/SS220/Maps/eclipse.yml
+++ b/Resources/Prototypes/SS220/Maps/eclipse.yml
@@ -29,7 +29,7 @@
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
             Detective: [ 1, 1 ]
-            SecurityPilot: [ 1, 1 ]
+            SecurityPilot: [ 1, 2 ]
             SecurityOfficer: [ 4, 5 ]
             SecurityCadet: [ 1, 2 ]
             Brigmedic: [ 1, 1 ]

--- a/Resources/Prototypes/SS220/Maps/frankenstein.yml
+++ b/Resources/Prototypes/SS220/Maps/frankenstein.yml
@@ -57,7 +57,7 @@
             SeniorOfficer: [ 1, 1]
             SecurityOfficer: [ 4, 5 ]
             Detective: [ 1, 1 ]
-            SecurityPilot: [ 1, 1 ]
+            SecurityPilot: [ 1, 2 ]
             SecurityCadet: [ 1, 2 ]
             Magistrate: [ 1, 1 ]
             IAA: [ 2, 2 ] # Corvax-IAA

--- a/Resources/Prototypes/SS220/Maps/tox.yml
+++ b/Resources/Prototypes/SS220/Maps/tox.yml
@@ -32,7 +32,7 @@
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
             Detective: [ 1, 1 ]
-            SecurityPilot: [ 1, 1 ]
+            SecurityPilot: [ 1, 2 ]
             SecurityOfficer: [ 4, 5 ]
             SecurityCadet: [ 1, 2 ]
             Brigmedic: [ 1, 1 ]


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Изменено количество доступных ролей офицеров службы безопасности раундстартом.

`*При указании 1/1 - первое число означает максимальное количество раундстарт ролей, а второе число максимальное количество для лейтджоина. Например при 1/1, будет максимально 1 роль раундстартом и лейтджоином, а при 1/2, 1 раундстартом и ещё одна лейтджоином.`

Основные изменения на большинстве карт:

Офицеры службы безопасности
Было: 6/6
Стало: 4/5

Пилоты службы безопасности
Было: 2/2
Стало: 1/2

Кадеты службы безопасности
Было: 4/4
Стало: 1/2

Не итог, обсуждаемо с маперами.

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl:
- tweak: Изменено максимальное количество офицеров, кадетов и пилотов службы безопасности на станциях.
