### PR TITLE
FieldShield fix indirect damage blocking

### DIFF
--- a/Content.Shared/SS220/FieldShield/FieldShieldComponent.cs
+++ b/Content.Shared/SS220/FieldShield/FieldShieldComponent.cs
@@ -1,9 +1,11 @@
 // © SS220, MIT full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/MIT_LICENSE.TXT
 
 using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
@@ -96,6 +98,19 @@ public partial struct FieldShieldData
             {"Cold", 0.5f},
             {"Stamina", 0.2f}
         }
+    };
+
+    /// <summary>
+    /// Indirect damage instances of these types are ignored by the shield entity.
+    /// </summary>
+    [DataField]
+    [AutoNetworkedField]
+    public List<ProtoId<DamageGroupPrototype>> IgnoredDamage = new()
+    {
+        "Airloss",
+        "Toxin",
+        "Genetic",
+        "Metaphysical"
     };
 
     [DataField]

--- a/Content.Shared/SS220/FieldShield/FieldShieldSystem.cs
+++ b/Content.Shared/SS220/FieldShield/FieldShieldSystem.cs
@@ -130,9 +130,13 @@ public sealed class FieldShieldProviderSystem : EntitySystem
         RemCompDeferred<FieldShieldComponent>(args.Equipee);
     }
 
-    private FixedPoint2 GetIgnoredDamage(Entity<FieldShieldComponent> entity, DamageSpecifier damage, EntityUid? origin)
+    private FixedPoint2 GetBlockableDamage(Entity<FieldShieldComponent> entity, DamageSpecifier damageSpec, EntityUid? origin)
     {
-        FixedPoint2 totalIgnored = FixedPoint2.Zero;
+        var totalIgnored = FixedPoint2.Zero;
+
+        var damage = DamageSpecifier.GetPositive(damageSpec);
+        if (damage.Empty)
+            return totalIgnored;
 
         // Lack of origin usually indicates indirect damage, e.g. status effect (burning), metabolism, ambient radiation.
         // Some sources of damage (projectile grenades) don't pass Origin, so we can't be a 100% sure what's hitting us.
@@ -149,7 +153,7 @@ public sealed class FieldShieldProviderSystem : EntitySystem
             }
         }
 
-        return totalIgnored;
+        return damage.GetTotal() - totalIgnored;
     }
 
     private void OnFieldShieldBeforeDamage(Entity<FieldShieldComponent> entity, ref BeforeDamageChangedEvent args)
@@ -157,15 +161,9 @@ public sealed class FieldShieldProviderSystem : EntitySystem
         if (args.Cancelled)
             return;
 
-        var damage = DamageSpecifier.GetPositive(args.Damage);
-
-        if (damage.Empty)
-            return;
-
-        var totalIgnored = GetIgnoredDamage(entity, damage, args.Origin);
-
-        if (damage.GetTotal() - totalIgnored > entity.Comp.ShieldData.MaxDamageConsumable
-            || damage.GetTotal() - totalIgnored < entity.Comp.ShieldData.DamageThreshold)
+        var blockableDamage = GetBlockableDamage(entity, args.Damage, args.Origin);
+        if (blockableDamage > entity.Comp.ShieldData.MaxDamageConsumable ||
+            blockableDamage < entity.Comp.ShieldData.DamageThreshold)
             return;
 
         UpdateShieldTimer(entity);
@@ -179,14 +177,8 @@ public sealed class FieldShieldProviderSystem : EntitySystem
 
     private void OnShieldDamageModify(Entity<FieldShieldComponent> entity, ref DamageModifyEvent args)
     {
-        var damage = DamageSpecifier.GetPositive(args.Damage);
-
-        if (damage.Empty)
-            return;
-
-        var totalIgnored = GetIgnoredDamage(entity, damage, args.Origin);
-
-        if (damage.GetTotal() - totalIgnored < entity.Comp.ShieldData.DamageThreshold)
+        var blockableDamage = GetBlockableDamage(entity, args.Damage, args.Origin);
+        if (blockableDamage < entity.Comp.ShieldData.DamageThreshold)
             return;
 
         UpdateShieldTimer(entity);

--- a/Content.Shared/SS220/FieldShield/FieldShieldSystem.cs
+++ b/Content.Shared/SS220/FieldShield/FieldShieldSystem.cs
@@ -3,10 +3,11 @@
 using Content.Shared.Damage;
 using Content.Shared.Emp;
 using Content.Shared.Examine;
+using Content.Shared.FixedPoint;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Popups;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.SS220.FieldShield;
@@ -16,6 +17,7 @@ public sealed class FieldShieldProviderSystem : EntitySystem
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
 
     private const int FieldShieldPushPriority = 2;
 
@@ -128,13 +130,42 @@ public sealed class FieldShieldProviderSystem : EntitySystem
         RemCompDeferred<FieldShieldComponent>(args.Equipee);
     }
 
+    private FixedPoint2 GetIgnoredDamage(Entity<FieldShieldComponent> entity, DamageSpecifier damage, EntityUid? origin)
+    {
+        FixedPoint2 totalIgnored = FixedPoint2.Zero;
+
+        // Lack of origin usually indicates indirect damage, e.g. status effect (burning), metabolism, ambient radiation.
+        // Some sources of damage (projectile grenades) don't pass Origin, so we can't be a 100% sure what's hitting us.
+        // Let's ignore safe bets - metabolic overdose, airloss, etc.
+        if (origin is null)
+        {
+            foreach (var groupType in entity.Comp.ShieldData.IgnoredDamage)
+            {
+                var damageGroup = _prototype.Index(groupType);
+                if (damage.TryGetDamageInGroup(damageGroup, out var total))
+                {
+                    totalIgnored += total;
+                }
+            }
+        }
+
+        return totalIgnored;
+    }
+
     private void OnFieldShieldBeforeDamage(Entity<FieldShieldComponent> entity, ref BeforeDamageChangedEvent args)
     {
         if (args.Cancelled)
             return;
 
-        if (args.Damage.GetTotal() > entity.Comp.ShieldData.MaxDamageConsumable
-            || args.Damage.GetTotal() < entity.Comp.ShieldData.DamageThreshold)
+        var damage = DamageSpecifier.GetPositive(args.Damage);
+
+        if (damage.Empty)
+            return;
+
+        var totalIgnored = GetIgnoredDamage(entity, damage, args.Origin);
+
+        if (damage.GetTotal() - totalIgnored > entity.Comp.ShieldData.MaxDamageConsumable
+            || damage.GetTotal() - totalIgnored < entity.Comp.ShieldData.DamageThreshold)
             return;
 
         UpdateShieldTimer(entity);
@@ -148,7 +179,14 @@ public sealed class FieldShieldProviderSystem : EntitySystem
 
     private void OnShieldDamageModify(Entity<FieldShieldComponent> entity, ref DamageModifyEvent args)
     {
-        if (args.OriginalDamage.GetTotal() < entity.Comp.ShieldData.DamageThreshold)
+        var damage = DamageSpecifier.GetPositive(args.Damage);
+
+        if (damage.Empty)
+            return;
+
+        var totalIgnored = GetIgnoredDamage(entity, damage, args.Origin);
+
+        if (damage.GetTotal() - totalIgnored < entity.Comp.ShieldData.DamageThreshold)
             return;
 
         UpdateShieldTimer(entity);


### PR DESCRIPTION
## Описание PR
Силовые щиты ригов больше не блокируют непрямой урон:
* кровопотеря
* удушение
* яды от передоза
* генетический урон (в т.ч. мозговой)

Прямой урон этих категорий всё еще блокируется - например, ядовитый выстрел паука-террора потратит заряд щита.

Система не идеальна, так как из текущих подписок мы не всегда можем понять что наносит урон. Даже с этим фиксом урон от разгерметизации все равно будет блокироваться щитом.

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl:
- fix: Силовые щиты ригов больше не защищают от удушения, передозировки и кровопотери.
