### PR TITLE
CultLifeFix

### DIFF
--- a/Resources/Prototypes/SS220/Entities/Clothing/CultYogg/CultYoggSuits.yml
+++ b/Resources/Prototypes/SS220/Entities/Clothing/CultYogg/CultYoggSuits.yml
@@ -56,6 +56,7 @@
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
+  - type: FlashImmunity
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/SS220/Entities/Clothing/CultYogg/CultYoggSuits.yml
+++ b/Resources/Prototypes/SS220/Entities/Clothing/CultYogg/CultYoggSuits.yml
@@ -36,6 +36,7 @@
   - type: StuckOnEquip
   - type: Tag
     tags:
+    - WhitelistChameleon
     - CultYoggStealthProvidable
 
 - type: entity
@@ -43,7 +44,6 @@
   id: ClothingHeadHelmetHardsuitCultYogg
   name: Hardsuit helmet corrupted by a Cult
   description: Corrupted pile of incomprehensible substane, somehowe prowiding great defence.
-  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: SS220/Clothing/Head/Hardsuits/cult_yogg.rsi
@@ -67,3 +67,6 @@
         Radiation: 0.5
   - type: FireProtection
     reduction: 0.2
+  - type: Tag
+    tags:
+    - WhitelistChameleon

--- a/Resources/Prototypes/SS220/Entities/Objects/Consumable/CultYogg/LubroShroom.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Consumable/CultYogg/LubroShroom.yml
@@ -65,9 +65,10 @@
   packetPrototype: LubroShroomSeeds
   productPrototypes:
     - FoodLubroShroomCult
+  harvestRepeat: Repeat
   lifespan: 55
-  maturation: 40
-  production: 2
+  maturation: 12
+  production: 10
   yield: 1
   potency: 2
   growthStages: 7

--- a/Resources/Prototypes/SS220/Entities/Objects/Consumable/CultYogg/LubroShroom.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Consumable/CultYogg/LubroShroom.yml
@@ -44,6 +44,7 @@
     tags:
     - Omnivorous
     - CultYoggStealthProvidable
+    - WhitelistChameleon
 
 - type: entity
   parent: SeedBase

--- a/Resources/Prototypes/SS220/Entities/Objects/Consumable/CultYogg/MiGomycete.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Consumable/CultYogg/MiGomycete.yml
@@ -50,9 +50,10 @@
   packetPrototype: MiGomyceteSeeds
   productPrototypes:
     - FoodMiGomyceteCult
+  harvestRepeat: Repeat
   lifespan: 25
   maturation: 12
-  production: 2
+  production: 5
   yield: 1
   potency: 2
   growthStages: 2

--- a/Resources/Prototypes/SS220/Entities/Objects/Consumable/CultYogg/MikoTrapShroom.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Consumable/CultYogg/MikoTrapShroom.yml
@@ -1,10 +1,9 @@
 - type: entity
   name: miko trap
-  parent: [BaseBearTrap, CultYoggRestrictedItem, FoodProduceBase]
+  parent: [BaseBearTrap, CultYoggRestrictedItem]
   id: FoodMikoTrapShroomCult
   description: a hidden mushroom trap for infidels.
   components:
-    - type: Food
     - type: Sprite
       sprite: SS220/Objects/CultYogg/miko_trap_shroom.rsi
       layers:
@@ -28,6 +27,8 @@
         components:
         - CultYogg
     - type: Trap
+      setTrapDelay: 2.5
+      defuseTrapDelay: 2.5
       durationStun: 1
       setTrapSound: /Audio/SS220/Items/CultYogg/sound_trapCult_set.ogg
       defuseTrapSound: /Audio/SS220/Items/CultYogg/sound_trapCult_defuse.ogg
@@ -35,27 +36,11 @@
     - type: Stealth
       minVisibility: -0.2
       maxVisibility: 2
-    - type: FlavorProfile
-      flavors:
-      - menacing
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          maxVol: 5.0
-          reagents:
-          - ReagentId: Nutriment
-            Quantity: 1
-          - ReagentId: Water
-            Quantity: 1
-          - ReagentId: Toxin
-            Quantity: 3
     - type: InjectionOnTrigger
       reagent: Toxin
       quantity: 3
     - type: Produce
       seedId: MikoTrapShroomSpores
-    - type: Extractable
-      grindableSolutionName: food
     - type: Tag
       tags:
       - Omnivorous
@@ -81,10 +66,11 @@
   packetPrototype: MikoTrapShroomSeeds
   productPrototypes:
   - FoodMikoTrapShroomCult
+  harvestRepeat: Repeat
   lifespan: 25
   maturation: 12
-  production: 2
-  yield: 1
+  production: 10
+  yield: 2
   potency: 2
   growthStages: 5
   chemicals:

--- a/Resources/Prototypes/SS220/Entities/Objects/Consumable/CultYogg/NullShroom.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Consumable/CultYogg/NullShroom.yml
@@ -48,10 +48,11 @@
   packetPrototype: NullificationShroomSeeds
   productPrototypes:
     - FoodNullificationShroomCult
+  harvestRepeat: Repeat
   lifespan: 25
   maturation: 12
-  production: 2
-  yield: 1
+  production: 10
+  yield: 2
   potency: 2
   growthStages: 7
   waterConsumption: 0.60

--- a/Resources/Prototypes/SS220/Entities/Objects/Consumable/CultYogg/SidiusShroom.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Consumable/CultYogg/SidiusShroom.yml
@@ -50,11 +50,12 @@
   packetPrototype: SidiousShroomSeeds
   productPrototypes:
     - FoodSidiousShroomCult
+  harvestRepeat: Repeat
   lifespan: 55
   maturation: 12
-  production: 2
-  yield: 1
-  potency: 30
+  production: 10
+  yield: 3
+  potency: 2
   growthStages: 7
   chemicals:
     Nutriment:

--- a/Resources/Prototypes/SS220/Entities/Objects/CultYogg/duffel.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/CultYogg/duffel.yml
@@ -26,3 +26,4 @@
   - type: Tag
     tags:
     - CultYoggStealthProvidable
+    - WhitelistChameleon

--- a/Resources/Prototypes/SS220/Entities/Objects/CultYogg/strangeFruit.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/CultYogg/strangeFruit.yml
@@ -130,9 +130,10 @@
   packetPrototype: CultStrangeFruitSeed
   productPrototypes:
     - ProductStrangeFruitCultYogg
+  harvestRepeat: Repeat
   lifespan: 25
   maturation: 12
-  production: 3
+  production: 10
   yield: 1
   potency: 10
   growthStages: 7


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->

 Растения культа были изменены в сторону большего удобства. Теперь всем растениям добавлен компонент ```harvestRepeat: Repeat``` который не даёт исчезнуть растению с ```грибницы``` после сбора. Такое изменение убирает зависимость постоянного урожая от ``Ми-Го`` и направляет её внимание на культистов. Так же итоговая скорость получения самих плодов была снижена благодаря ```harvestRepeat: Repeat``` ибо для получения первого плода растение тратило около 5 минут и требовала повторную посадку, сейчас растение тратит 5 минут на первый плод и 2.30 на дальнейший плод. 

По итогу выгоднее теперь делать по 6 лотков и растить по 1 грибу каждого вида не засирая пол грядками, если кто то скажет следующее ``но они же вырастят к концу игры по около 60 плодов и тд`` такая урожайность может быть лишь к концу идеальной стелс игры но я же считаю что нерфы и баффы культа быть направлены в те условия где культ был найден ещё в середине игры ибо сейчас культ может играться лишь в мире где он сам себя раскрывает а не его.

Особые изменения следующие:
  - ```Луброгус``` теперь не растёт 15 минут выдавая лишь 1 пару туфель, а как и другие около 5 минут но плодоносит дольше других.
  - ```Сидиус``` гриб потерял в размере спрайта благодаря уменьшению потенции, до этого он имел громоздкие размеры спрайта но уменьшение его потенции никак не повлияло на содержимое внутри и он так же полезен в роли еды. Кроме того он теперь плодоносит по 3 гриба.
  - ```Миколовушка``` теперь плодоносит по 2 плода, увеличение количества ловушек никак не превращает игру в сапёра ибо на всю игру стоит ограничение в 6 активированных капканов культа. У ```Миколовушки``` были убраны компоненты связанные с едой ибо в первую очередь это капкан а не еда и с компонентами еды, для его активации надо было его класть на пол и через ПКМ прожимать взвести, в добавок к этому если на карте уже было максимальное число ловушек культист его просто съедал, не успевая среагировать, и получал отравление.
  
У шлема скафандра культа был добавлен компонент ```type: FlashImmunity```. Логично что до вербовки член экипажа не обязан манчить себе защиту глаз но после неё быть без защиты равно смерти. Теперь же всё это встроено в скафандр.
А ещё был добавлена сумка культа, ботинки культа, скафандр культа его шлем в выбор набора хамелеона. Это мне когда то Скал разрешил но что то руки только щас дошли. У нас и так есть скафы ядера и щитспавн скафы в хамелеоне почему бы и не добавить эти вещи для РП агентов.

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру и на дискорд сервер, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->

:cl: Hvoev (обновление уже на серверах!)
- tweak: Изменены растения культа, теперь они не требуют повторной посадки после сбора и дают больше плодов.
- tweak: Изменен шлем скафандра культа, теперь в него встроена защита глаз от вспышек.
- tweak: Изменена скорость взведения и разминирования Миколовушки, теперь она в 2 раза меньше.
- add: Добавлена одежда культа в выбор хамелеона.

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Добавлено веселье!
- remove: Убрано веселье!
- tweak: Изменено веселье!
- fix: Исправлено веселье!
-->
