### PR TITLE
[FIX] Wizard spell speak

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -170,9 +170,9 @@ public sealed partial class ChatSystem : SharedChatSystem
         ICommonSession? player = null, string? nameOverride = null,
         bool checkRadioPrefix = true,
         bool ignoreActionBlocker = false,
-        bool bypyssEnglishFilter = false) // SS220 FIX wizard spell speak
+        bool bypassEnglishFilter = false) // SS220 FIX wizard spell speak
     {
-        TrySendInGameICMessage(source, message, desiredType, hideChat ? ChatTransmitRange.HideChat : ChatTransmitRange.Normal, hideLog, shell, player, nameOverride, checkRadioPrefix, ignoreActionBlocker, bypyssEnglishFilter); // SS220 FIX wizard spell speak
+        TrySendInGameICMessage(source, message, desiredType, hideChat ? ChatTransmitRange.HideChat : ChatTransmitRange.Normal, hideLog, shell, player, nameOverride, checkRadioPrefix, ignoreActionBlocker, bypassEnglishFilter); // SS220 FIX wizard spell speak
     }
 
     /// <summary>
@@ -197,7 +197,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         string? nameOverride = null,
         bool checkRadioPrefix = true,
         bool ignoreActionBlocker = false,
-        bool bypyssEnglishFilter = false // SS220 FIX wizard spell speak
+        bool bypassEnglishFilter = false // SS220 FIX wizard spell speak
         )
     {
         if (HasComp<GhostComponent>(source))
@@ -248,7 +248,7 @@ public sealed partial class ChatSystem : SharedChatSystem
             || (CultureInfo.CurrentCulture.IsNeutralCulture && CultureInfo.CurrentCulture.Name == "en");
 
         message = _chatManager.DeleteProhibitedCharacters(message, source); // SS220 delete prohibited characters
-        message = SanitizeInGameICMessage(source, message, /* SS220 languages */ desiredType, out var emoteStr, shouldCapitalize, shouldPunctuate, shouldCapitalizeTheWordI, bypyssEnglishFilter); // SS220 FIX wizard spell speak
+        message = SanitizeInGameICMessage(source, message, /* SS220 languages */ desiredType, out var emoteStr, shouldCapitalize, shouldPunctuate, shouldCapitalizeTheWordI, bypassEnglishFilter); // SS220 FIX wizard spell speak
 
         // Was there an emote in the message? If so, send it.
         if (player != null && emoteStr != message && emoteStr != null)
@@ -906,7 +906,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         bool capitalize = true,
         bool punctuate = false,
         bool capitalizeTheWordI = true,
-        bool bypyssEnglishFilter = false) // SS220 FIX wizard spell speak
+        bool bypassEnglishFilter = false) // SS220 FIX wizard spell speak
     {
         var newMessage = message.Trim();
         // SS220 languages begin
@@ -964,7 +964,7 @@ public sealed partial class ChatSystem : SharedChatSystem
                 GetRadioKeycodePrefix(source, newMessage, out newMessage, out prefix);
 
             _sanitizer.TrySanitizeEmoteShorthands(newMessage, source, out newMessage, out newEmoteStr);
-            if (!bypyssEnglishFilter && !_sanitizer.CheckNoEnglish(source, newMessage)) // SS220 FIX wizard spell speak
+            if (!bypassEnglishFilter && !_sanitizer.CheckNoEnglish(source, newMessage)) // SS220 FIX wizard spell speak
                 foundEnglish = true;
 
             if (capitalize)

--- a/Content.Server/Speech/EntitySystems/SpeakOnActionSystem.cs
+++ b/Content.Server/Speech/EntitySystems/SpeakOnActionSystem.cs
@@ -34,6 +34,6 @@ public sealed class SpeakOnActionSystem : SharedSpeakOnActionSystem
         if (string.IsNullOrWhiteSpace(ent.Comp.Sentence))
             return;
 
-        _chat.TrySendInGameICMessage(user, Loc.GetString(ent.Comp.Sentence), InGameICChatType.Speak, false, bypyssEnglishFilter: true); // SS220 FIX wizard spell speak
+        _chat.TrySendInGameICMessage(user, Loc.GetString(ent.Comp.Sentence), InGameICChatType.Speak, false, bypassEnglishFilter: true); // SS220 FIX wizard spell speak
     }
 }


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Добавляет флаг `bypassEnglishFilter` в методы `TrySendInGameICMessage` и `SanitizeInGameICMessage` из системы чата, чтобы спич из `SpeakOnActionSystem` обходил обходил блокировку английских символов.

Первоначально пытался через проверку на компонент типа `if (HasComp<SpeakOnActionComponent>(source) && !_sanitizer.CheckNoEnglish(source, newMessage))` сделать, но тогда фильтр отключается полностью, поэтому как-то так

close: https://github.com/SerbiaStrong-220/space-station-14/issues/2870

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl:
- fix: Исправлено произношение заклинаний волшебником. Теперь он может их произносить!
