### PR TITLE
FIX: Alert level after SM explosion

### DIFF
--- a/Content.Server/SS220/SuperMatter/Crystal/SuperMatterSystem.Delamination.cs
+++ b/Content.Server/SS220/SuperMatter/Crystal/SuperMatterSystem.Delamination.cs
@@ -131,7 +131,10 @@ public sealed partial class SuperMatterSystem
             && TryComp<TeslaEnergyBallComponent>(spawnedUid.Value, out var teslaComp))
             _teslaEnergyBall.AdjustEnergy(spawnedUid.Value, teslaComp, 1000f);
 
-       // TryChangeStationAlertLevel(crystal, crystal.Comp.CrystalDestroyAlertLevel, out _);
+        var station = _station.GetOwningStation(crystal.Owner);
+        if (TryComp<AlertLevelComponent>(station, out var alertLevel))
+            alertLevel.IsLevelLocked = false;
+
         StationAnnounceIntegrity(crystal, AnnounceIntegrityTypeEnum.Explosion, smState);
     }
 }

--- a/Content.Server/SS220/SuperMatter/Crystal/SuperMatterSystem.Delamination.cs
+++ b/Content.Server/SS220/SuperMatter/Crystal/SuperMatterSystem.Delamination.cs
@@ -131,10 +131,7 @@ public sealed partial class SuperMatterSystem
             && TryComp<TeslaEnergyBallComponent>(spawnedUid.Value, out var teslaComp))
             _teslaEnergyBall.AdjustEnergy(spawnedUid.Value, teslaComp, 1000f);
 
-        var station = _station.GetOwningStation(crystal.Owner);
-        if (TryComp<AlertLevelComponent>(station, out var alertLevel))
-            alertLevel.IsLevelLocked = false;
-
+        // TryChangeStationAlertLevel(crystal, crystal.Comp.CrystalDestroyAlertLevel, out _);
         StationAnnounceIntegrity(crystal, AnnounceIntegrityTypeEnum.Explosion, smState);
     }
 }

--- a/Content.Server/SS220/SuperMatter/Crystal/SuperMatterSystem.Delamination.cs
+++ b/Content.Server/SS220/SuperMatter/Crystal/SuperMatterSystem.Delamination.cs
@@ -131,7 +131,7 @@ public sealed partial class SuperMatterSystem
             && TryComp<TeslaEnergyBallComponent>(spawnedUid.Value, out var teslaComp))
             _teslaEnergyBall.AdjustEnergy(spawnedUid.Value, teslaComp, 1000f);
 
-        // TryChangeStationAlertLevel(crystal, crystal.Comp.CrystalDestroyAlertLevel, out _);
+       // TryChangeStationAlertLevel(crystal, crystal.Comp.CrystalDestroyAlertLevel, out _);
         StationAnnounceIntegrity(crystal, AnnounceIntegrityTypeEnum.Explosion, smState);
     }
 }

--- a/Content.Server/SS220/SuperMatter/Crystal/SuperMatterSystem.Report.cs
+++ b/Content.Server/SS220/SuperMatter/Crystal/SuperMatterSystem.Report.cs
@@ -83,7 +83,7 @@ public sealed partial class SuperMatterSystem
         _chatSystem.DispatchStationAnnouncement(uid, message, localizedSender, colorOverride: Color.FromHex("#deb63d"));
     }
 
-    private bool TryChangeStationAlertLevel(Entity<SuperMatterComponent> crystal, string alertLevel, [NotNullWhen(true)] out string? previousAlertLevel, bool force = true, bool locked = true)
+    private bool TryChangeStationAlertLevel(Entity<SuperMatterComponent> crystal, string alertLevel, [NotNullWhen(true)] out string? previousAlertLevel, bool force = true, bool locked = false)
     {
         previousAlertLevel = null;
         var stationUid = _station.GetStationInMap(Transform(crystal.Owner).MapID);


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Теперь после взрыва СМ снова можно менять код на станции

(fix: https://github.com/SerbiaStrong-220/space-station-14/issues/4137)

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

no cl