### PR TITLE
Revert experimental updates

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.API.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.cs
@@ -103,7 +103,7 @@ public sealed partial class AntagSelectionSystem
         // make sure we don't double-count the current selection
         countOffset -= Math.Clamp(poolSize / def.PlayerRatio, def.Min, def.Max) * def.PlayerRatio;
 
-        return Math.Clamp((poolSize - countOffset + (int)(def.PlayerRatio * def.AddPlayerCountPerRatio)) / def.PlayerRatio, def.Min, def.Max); // SS220-give-more-flex-to-antag-selection
+        return Math.Clamp((poolSize - countOffset) / def.PlayerRatio, def.Min, def.Max);
     }
 
     /// <summary>

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -197,7 +197,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             DebugTools.AssertNotEqual(antag.SelectionTime, AntagSelectionTime.PrePlayerSpawn);
 
             // do not count players in the lobby for the antag ratio
-            var players = PlayerManager.Sessions.Count(session => session.Status is not (SessionStatus.Disconnected or SessionStatus.Zombie)); // SS220-make-antag-selection-based-on-all-players
+            var players = _playerManager.NetworkedSessions.Count(x => x.AttachedEntity != null);
 
             if (!TryGetNextAvailableDefinition((uid, antag), out var def, players))
                 continue;
@@ -282,8 +282,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     {
         var playerPool = GetPlayerPool(ent, pool, def);
         var existingAntagCount = ent.Comp.PreSelectedSessions.TryGetValue(def, out var existingAntags) ?  existingAntags.Count : 0;
-        var allPlayerCount = PlayerManager.Sessions.Count(session => session.Status is not (SessionStatus.Disconnected or SessionStatus.Zombie)); // SS220-make-antag-selection-based-on-all-players
-        var count = GetTargetAntagCount(ent, allPlayerCount, def) - existingAntagCount; // SS220 GetTotalPlayerCount(pool) -> allPlayerCount
+        var count = GetTargetAntagCount(ent, GetTotalPlayerCount(pool), def) - existingAntagCount;
 
         // if there is both a spawner and players getting picked, let it fall back to a spawner.
         var noSpawner = def.SpawnerPrototype == null;

--- a/Content.Server/Antag/Components/AntagSelectionComponent.cs
+++ b/Content.Server/Antag/Components/AntagSelectionComponent.cs
@@ -121,15 +121,6 @@ public partial struct AntagSelectionDefinition()
     [DataField]
     public int PlayerRatio = 10;
 
-    // SS220-add-adjustment-for-antag-count-begin
-    /// <summary>
-    /// On antag number computing that value is being added to player count multiplied by PlayerRation <br/>
-    /// Can be used to fine tune antag count without changing player ratio
-    /// </summary>
-    [DataField]
-    public float AddPlayerCountPerRatio = 0f;
-    // SS220-add-adjustment-for-antag-count-begin
-
     /// <summary>
     /// Whether or not players should be picked to inhabit this antag or not.
     /// If no players are left and <see cref="SpawnerPrototype"/> is set, it will make a ghost role.

--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -12,7 +12,6 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Configuration;
 using Robust.Shared.Utility;
-using Robust.Shared.Enums;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -77,7 +76,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     private bool TryPickPreset(ProtoId<WeightedRandomPrototype> weights, [NotNullWhen(true)] out GamePresetPrototype? preset)
     {
         var options = _prototypeManager.Index(weights).Weights.ShallowClone();
-        var players = PlayerManager.Sessions.Count(session => session.Status is not (SessionStatus.Disconnected or SessionStatus.Zombie)); // SS220-make-antag-selection-based-on-all-players
+        var players = GameTicker.ReadyPlayerCount();
 
         // SS220 Cult Yogg begin
         var optionsToRemove = new HashSet<string>();

--- a/Content.Server/SS220/GameTicking/Rules/Components/EmergencyShuttleAutoVoteRuleComponent.cs
+++ b/Content.Server/SS220/GameTicking/Rules/Components/EmergencyShuttleAutoVoteRuleComponent.cs
@@ -10,7 +10,7 @@ public sealed partial class EmergencyShuttleAutoVoteRuleComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan LastEvacVoteTime = TimeSpan.Zero;
-        
+
     [ViewVariables]
     public int EvacVoteCount = 0;
 
@@ -18,7 +18,7 @@ public sealed partial class EmergencyShuttleAutoVoteRuleComponent : Component
     /// Time after round start when we want to make first vote for round end
     /// </summary>
     [DataField]
-    public TimeSpan VoteStartTime = TimeSpan.FromMinutes(80f);
+    public TimeSpan VoteStartTime = TimeSpan.FromMinutes(110f);
 
     /// <summary>
     /// How much time we wait before next vote

--- a/Content.Server/StationEvents/Components/BasicStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/BasicStationEventSchedulerComponent.cs
@@ -13,14 +13,14 @@ public sealed partial class BasicStationEventSchedulerComponent : Component
     [DataField]
     // public float MinimumTimeUntilFirstEvent = 200; // [wizden-code]
     // It has hard-coded random addition +2 minutes so first event fire in [3, 5] minutes of round
-    public float MinimumTimeUntilFirstEvent = 180f; //SS220-cut-round-duration
+    public float MinimumTimeUntilFirstEvent = 200f; //SS220-cut-round-duration
 
     /// <summary>
     /// The minimum and maximum time between rule starts in seconds.
     /// </summary>
     [DataField]
     // public MinMax MinMaxEventTiming = new(3 * 60, 10 * 60); // [wizden-code]
-    public MinMax MinMaxEventTiming = new(60 * 5, 60 * 10); //SS220-cut-round-duration
+    public MinMax MinMaxEventTiming = new(60 * 6, 60 * 12); //SS220-cut-round-duration
 
     /// <summary>
     /// How long until the next check for an event runs, is initially set based on MinimumTimeUntilFirstEvent & MinMaxEventTiming.

--- a/Resources/Locale/ru-RU/ss220/objectives/ninja.ftl
+++ b/Resources/Locale/ru-RU/ss220/objectives/ninja.ftl
@@ -2,17 +2,17 @@ objective-condition-frame-target-title =  Подставьте { $targetName }, 
 ent-NinjaFrameTargetObjective = Подставить цель
     .desc = Этот сотрудник избегает правосудия, исправьте это. Подставьте цель так, что дойдёт до заключения в бриге станции. Следите чтобы пометки оставались и в криминальных записях.
 
-objective-condition-intimidate-target-brute-title = Заказ на устрашение { $targetName }, в должности { CAPITALIZE($job) }.
+objective-condition-intimidate-target-brute-title = Заказ на запугивание { $targetName }, в должности { CAPITALIZE($job) }.
 objective-condition-intimidate-target-brute-desc = Вам заказали преподать урок члену экипажа станции. Избейте вашу цель несколько раз, пока она в ясном сознании.
 objective-condition-intimidate-target-brute-desc-ssd= Цель впала в ССД, такой исход тоже возможен.
 objective-condition-intimidate-target-brute-desc-success = Вы успешно преподали урок.
 
-objective-condition-intimidate-target-burn-title = Заказ на устрашение { $targetName }, в должности { CAPITALIZE($job) }.
+objective-condition-intimidate-target-burn-title = Заказ на запугивание { $targetName }, в должности { CAPITALIZE($job) }.
 objective-condition-intimidate-target-burn-desc = Вам заказали преподать урок члену экипажа станции. Нанесите вашей цели достаточно ожогов, пока она в ясном сознании.
 objective-condition-intimidate-target-burn-desc-ssd= Цель впала в ССД, такой исход тоже возможен.
 objective-condition-intimidate-target-burn-desc-success = Вы успешно преподали урок.
 
-objective-condition-intimidate-target-toxin-title = Заказ на устрашение { $targetName }, в должности { CAPITALIZE($job) }.
+objective-condition-intimidate-target-toxin-title = Заказ на запугивание { $targetName }, в должности { CAPITALIZE($job) }.
 objective-condition-intimidate-target-toxin-desc = Вам заказали преподать урок члену экипажа станции. Отравите вашу цель несколько раз, пока она в ясном сознании.
 objective-condition-intimidate-target-toxin-desc-ssd= Цель впала в ССД, такой исход тоже возможен.
 objective-condition-intimidate-target-toxin-desc-success = Вы успешно преподали урок.

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -634,7 +634,7 @@
   - type: StationEvent
     earliestStart: 50
     minimumPlayers: 30
-    weight: 1 # SS220 Zombie tweak
+    weight: 3
     duration: 1
   - type: ZombieRule
   - type: AntagSelection

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -221,7 +221,7 @@
   id: DragonSpawn
   components:
   - type: StationEvent
-    weight: 6.5
+    weight: 9.5 # ss220 upraise midround events
     earliestStart: 40
     reoccurrenceDelay: 20
     minimumPlayers: 20
@@ -252,7 +252,7 @@
   id: NinjaSpawn
   components:
   - type: StationEvent
-    weight: 6
+    weight: 9 # ss220 upraise midround events
     duration: null
     earliestStart: 30
     reoccurrenceDelay: 20
@@ -324,7 +324,7 @@
   id: ParadoxCloneSpawn
   components:
   - type: StationEvent
-    weight: 5
+    weight: 8 # ss220 upraise midround events
     duration: null
     earliestStart: 20
     reoccurrenceDelay: 20
@@ -362,7 +362,7 @@
   id: RevenantSpawn
   components:
   - type: StationEvent
-    weight: 7.5
+    weight: 10.5 # ss220 upraise midround events
     duration: 1
     earliestStart: 45
     minimumPlayers: 20
@@ -374,7 +374,7 @@
   id: WizardSpawn
   components:
   - type: StationEvent
-    weight: 0.1 # SS 220 0.1 weight wiz spawn midround
+    weight: 0.2 # ss220 upraise midround events
     duration: 1
     earliestStart: 30
     reoccurrenceDelay: 60
@@ -634,7 +634,7 @@
   - type: StationEvent
     earliestStart: 50
     minimumPlayers: 30
-    weight: 3
+    weight: 5 # ss220 upraise midround events
     duration: 1
   - type: ZombieRule
   - type: AntagSelection
@@ -718,7 +718,7 @@
   components:
   - type: StationEvent
     earliestStart: 30
-    weight: 8
+    weight: 9 # ss220 upraise midround events
     minimumPlayers: 15
     maxOccurrences: 1 # can only happen once per round
     startAnnouncement: station-event-communication-interception

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -115,7 +115,7 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 35 # SS220 Nukeops ratio fix
+    minPlayers: 25 # SS220 Nukeops ratio fix
   - type: LoadMapRule
     mapPath: /Maps/SS220/ss220-nukeoutpost.yml
   - type: AntagSelection

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -177,7 +177,6 @@
       min: 0 # SS220 Nukeops ratio fix
       max: 3
       playerRatio: 23 # SS220 Nukeops ratio fix
-      addPlayerCountPerRatio: 1 # SS220-nuke-spawn-in-segment
       startingGear: SyndicateOperativeGearFull
       roleLoadout:
       - RoleSurvivalNukie

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -48,6 +48,7 @@
   weights:
 #    RandomTraitorAliveObjective: 1 - Removed because the objective was boring and didn't progress the round.
     RandomTraitorProgressObjective: 1
+    TraitorIntimidateTargetGroup: 1
 
 #Thief groups
 - type: weightedRandom

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -47,10 +47,12 @@
   id: TraitorObjectiveGroupSocial
   weights:
 #    RandomTraitorAliveObjective: 1 - Removed because the objective was boring and didn't progress the round.
+    # ss220 upraise midround events begin
     RandomTraitorProgressObjective: 4
     TraitorIntimidateBruteTargetObjective: 5 # easiest
     TraitorIntimidateBurnTargetObjective: 3
     TraitorIntimidateToxinTargetObjective: 1 # hardest
+     # ss220 upraise midround events end
 
 #Thief groups
 - type: weightedRandom

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -47,8 +47,10 @@
   id: TraitorObjectiveGroupSocial
   weights:
 #    RandomTraitorAliveObjective: 1 - Removed because the objective was boring and didn't progress the round.
-    RandomTraitorProgressObjective: 1
-    TraitorIntimidateTargetGroup: 1
+    RandomTraitorProgressObjective: 4
+    TraitorIntimidateBruteTargetObjective: 5 # easiest
+    TraitorIntimidateBurnTargetObjective: 3
+    TraitorIntimidateToxinTargetObjective: 1 # hardest
 
 #Thief groups
 - type: weightedRandom

--- a/Resources/Prototypes/SS220/GameRules/roundstart.yml
+++ b/Resources/Prototypes/SS220/GameRules/roundstart.yml
@@ -115,6 +115,6 @@
     minimumTimeUntilFirstEvent: 1200 # 20 mins
     minMaxEventTiming:
       min: 600 # 10 mins
-      max: 1800 # 15 mins
+      max: 1800 # 30 mins
     scheduledGameRules: !type:NestedSelector
       tableId: UnknownShuttlesNeutralTable

--- a/Resources/Prototypes/SS220/GameRules/roundstart.yml
+++ b/Resources/Prototypes/SS220/GameRules/roundstart.yml
@@ -106,3 +106,15 @@
   parent: Traitor
   components:
   - type: TraitorDynamics
+
+- type: entity
+  id: SpaceTrafficControlNeutralEventScheduler
+  parent: BaseGameRule
+  components:
+  - type: BasicStationEventScheduler
+    minimumTimeUntilFirstEvent: 1200 # 20 mins
+    minMaxEventTiming:
+      min: 600 # 10 mins
+      max: 1800 # 15 mins
+    scheduledGameRules: !type:NestedSelector
+      tableId: UnknownShuttlesNeutralTable

--- a/Resources/Prototypes/SS220/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/SS220/GameRules/unknown_shuttles.yml
@@ -1,3 +1,22 @@
+- type: entityTable
+  id: UnknownShuttlesNeutralTable
+  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+    children:
+    - id: UnknownShuttleCargoLost
+      weight: 1
+    - id: UnknownShuttleTravelingCuisine
+      weight: 1
+    - id: UnknownShuttleDisasterEvacPod
+      weight: 2
+    - id: UnknownShuttleHonki
+      weight: 2
+    - id: UnknownShuttleCivil # SS220-Mimes-Lost-Shuttle
+      weight: 1
+    - id: UnknownShuttleMimesLost # SS220-Mimes-Lost-Shuttle
+      weight: 2
+    - id: UnknownShuttleRedwings # SS220-Redwings-Shuttle
+      weight: 5
+
 - type: entity
   parent: BaseUnknownShuttleRule
   id: UnknownShuttleCivil

--- a/Resources/Prototypes/SS220/Objectives/traitor.yml
+++ b/Resources/Prototypes/SS220/Objectives/traitor.yml
@@ -58,3 +58,60 @@
   - type: StealCondition
     stealGroup: RCDCE
     owner: job-name-ce
+
+- type: entity
+  parent: BaseTraitorStealObjective
+  id: TraitorIntimidateBruteTargetObjective
+  components:
+  - type: Objective
+    icon:
+      sprite: SS220/Objectives/intimidate.rsi
+      state: brute
+  - type: TargetObjective
+    title: objective-condition-intimidate-target-brute-title
+  - type: IntimidatePersonCondition
+    startDescription: objective-condition-intimidate-target-brute-desc
+    successDescription: objective-condition-intimidate-target-brute-desc-success
+    sSDDescription: objective-condition-intimidate-target-brute-desc-ssd
+    damageTrackerSpecifier:
+      damageGroup: Brute
+      allowedState: [Alive]
+      targetAmount: 280
+
+- type: entity
+  parent: BaseTraitorStealObjective
+  id: TraitorIntimidateBurnTargetObjective
+  components:
+  - type: Objective
+    icon:
+      sprite: SS220/Objectives/intimidate.rsi
+      state: burn
+  - type: TargetObjective
+    title: objective-condition-intimidate-target-burn-title
+  - type: IntimidatePersonCondition
+    startDescription: objective-condition-intimidate-target-burn-desc
+    successDescription: objective-condition-intimidate-target-burn-desc-success
+    sSDDescription: objective-condition-intimidate-target-burn-desc-ssd
+    damageTrackerSpecifier:
+      damageGroup: Burn
+      allowedState: [Alive]
+      targetAmount: 160
+
+- type: entity
+  parent: BaseTraitorStealObjective
+  id: TraitorIntimidateToxinTargetObjective
+  components:
+  - type: Objective
+    icon:
+      sprite: SS220/Objectives/intimidate.rsi
+      state: toxin
+  - type: TargetObjective
+    title: objective-condition-intimidate-target-toxin-title
+  - type: IntimidatePersonCondition
+    startDescription: objective-condition-intimidate-target-toxin-desc
+    successDescription: objective-condition-intimidate-target-toxin-desc-success
+    sSDDescription: objective-condition-intimidate-target-toxin-desc-ssd
+    damageTrackerSpecifier:
+      damageGroup: Toxin
+      allowedState: [Alive]
+      targetAmount: 120

--- a/Resources/Prototypes/SS220/Objectives/traitorGroup.yml
+++ b/Resources/Prototypes/SS220/Objectives/traitorGroup.yml
@@ -1,0 +1,6 @@
+- type: weightedRandom
+  id: TraitorIntimidateTargetGroup
+  weights:
+    TraitorIntimidateBruteTargetObjective: 5 # easiest
+    TraitorIntimidateBurnTargetObjective: 3
+    TraitorIntimidateToxinTargetObjective: 1 # hardest

--- a/Resources/Prototypes/SS220/game_presets.yml
+++ b/Resources/Prototypes/SS220/game_presets.yml
@@ -23,7 +23,10 @@
   maxPlayers: 59 # WARNING: this should be always synced with other cult game rules and presets!
   rules:
   - CultYoggRuleMidPop
+  - BasicRoundstartVariation
+  - SubGamemodesRule
   - NoNewCrewAntagsStationEventScheduler
+  - SpaceTrafficControlFriendlyEventScheduler
   - EmergencyShuttleAutoVote
 
 
@@ -38,7 +41,11 @@
   minPlayers: 60 # WARNING: this should be always synced with other cult game rules and presets!
   rules:
   - CultYoggRuleHighPop
+  - BasicRoundstartVariation
+  - SubGamemodesRule
+  - MeteorSwarmScheduler
   - NoNewCrewAntagsStationEventScheduler
+  - SpaceTrafficControlFriendlyEventScheduler
   - EmergencyShuttleAutoVote
 
 - type: gamePreset
@@ -90,8 +97,8 @@
     - id: KingRatMigration
     - id: NinjaSpawn
     - id: RevenantSpawn
-    #- id: SleeperAgents
-    #- id: ZombieOutbreak
+    - id: SleeperAgents
+    # - id: ZombieOutbreak
     - id: DarkReaperSpawn #ss220 darkreaper middle event
     - id: SpiderQueenSpawn #SS220 spider queen midround event
     - id: LoneOpsSpawn

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -40,7 +40,7 @@
   showInVote: false
   rules:
     - Nukeops
-    - Dynamic # ss220 traitor to dynamic
+    - Traitor
     # - Revolutionary
     - Zombie
     - Wizard
@@ -63,7 +63,7 @@
   showInVote: false #Please god dont do this
   rules:
     - Nukeops
-    - Dynamic # ss220 traitor to dynamic
+    - Traitor
     - Revolutionary
     - Zombie
     - Wizard

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -10,7 +10,7 @@
     - MeteorSwarmScheduler
     - RampingStationEventScheduler
     # - SpaceTrafficControlEventScheduler # SS220-NoUnknownShuttles
-    - SpaceTrafficControlFriendlyEventScheduler
+    - SpaceTrafficControlNeutralEventScheduler # SS220-LostSouls
     - BasicRoundstartVariation
     - EmergencyShuttleAutoVote # SS220-evac-vote
 
@@ -27,7 +27,7 @@
     - KesslerSyndromeScheduler
     - RampingStationEventScheduler
     # - SpaceTrafficControlEventScheduler # SS220-NoUnknownShuttles
-    - SpaceTrafficControlFriendlyEventScheduler # SS220-LostSouls
+    - SpaceTrafficControlNeutralEventScheduler # SS220-LostSouls
     - BasicRoundstartVariation
     - EmergencyShuttleAutoVote # SS220-evac-vote
 
@@ -40,14 +40,14 @@
   showInVote: false
   rules:
     - Nukeops
-    - Traitor
+    - Dynamic # ss220 traitor to dynamic
     # - Revolutionary
     - Zombie
     - Wizard
     - KesslerSyndromeScheduler
     - RampingStationEventScheduler
     # - SpaceTrafficControlEventScheduler # SS220-NoUnknownShuttles
-    - SpaceTrafficControlFriendlyEventScheduler # SS220-LostSouls
+    - SpaceTrafficControlNeutralEventScheduler # SS220-LostSouls
     - BasicRoundstartVariation
     - EmergencyShuttleAutoVote # SS220-evac-vote
 
@@ -63,7 +63,7 @@
   showInVote: false #Please god dont do this
   rules:
     - Nukeops
-    - Traitor
+    - Dynamic # ss220 traitor to dynamic
     - Revolutionary
     - Zombie
     - Wizard
@@ -73,7 +73,7 @@
     - MeteorSwarmScheduler
     - RampingStationEventScheduler
     # - SpaceTrafficControlEventScheduler # SS220-NoUnknownShuttles
-    - SpaceTrafficControlFriendlyEventScheduler
+    - SpaceTrafficControlNeutralEventScheduler # SS220-LostSouls
     - BasicRoundstartVariation
     - EmergencyShuttleAutoVote # SS220-evac-vote
 

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,17 +2,17 @@
   id: Secret
   weights:
     # SS220 Secret Valid Weights bgn
-    Nukeops: 0.12
+    Nukeops: 0.18
     #Traitor: 0.6
-    DynamicTraitor: 0.6 #replacing default traitors with DynamicTraitor
+    DynamicTraitor: 0.54 #replacing default traitors with DynamicTraitor
 
     # At the moment game will add to pool single cult preset (because of min/max players count), so other cult preset(s) will be ignored completely.
-    CultYoggPresetMidPop: 0.3
-    CultYoggPresetHighPop: 0.3
+    CultYoggPresetMidPop: 0.25
+    CultYoggPresetHighPop: 0.25
 
     # Zombie: 0.18
     Extended: 0.04
-    Survival: 0.1
+    Survival: 0.18
     # DarkReaper: 0.18
     # Revolutionary: 0.18 #No Revs yet
     Wizard: 0.01


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Эксперименты закончены, пора возвращаться домой.
По итогам были собраны данные для анализа за полгода с разным плейстайлом игры. Первый это более растянутый геймплей с меньшим количеством событий, с затяжными целями и раундстартом от количества готовых. Второй это более динамичный геймплей, с короткими задержками между событиями и раундстартом от количества игроков в целом.

Что показало себя хорошо:
- Сокращение задержек между событиями
- Упрощение духоты целей

Что показало себя сомнительно:
- Автоэвак на 1:20, на него поступало много жалоб, но он сформировал нужную нам тенденцию в игру вместо трех часов в два часа раунда
- Количество готовых от лобби, а не от готово. Мы получили наилучший результат в сильном снижении "расширенного" режима на неделю, однако при этом ошибочных инста-гамма культов и проблем с черт пойми какими ЯО набиралось не мало.

Какой план?
Во первых, данные всё ещё не проанализированы дотошно. Это займёт какое-то время, но после анализа будут видны четкие тенденции до и после. Сейчас нужно нащупать золотую середину, чуть откатившись назад от изменений, что вызывали бучу и дать некую медиану, чтобы по ней потом также сравнить ситуацию до и после в разрезе Апрель/Май.

По итогу:
- Возвращаемся обратно на подсчёт игроков для раундстарта от количества готовых
- Оставляем сокращённые цели станции
- Оставляем зедержки между событиями на уровне среднем между до и после
- Сдвигаем автоэвак на 1:50, под заданный полу-естественным образом тайминг раундов
- Изменяем шансы режимов раундстарта и мидраунда. Повышаем мажорные мидраунд события в шансе, в том числе на зомби и волшебника. Перебрасываем несколько пунктов с динамика и культа на нюкеров и выживание.

А также дополнительно добавляем цель на ~~устрашение~~ запугивание агентам, добавляем повышенные шансы RedWings в выживании. Добавляем в режим культа больше событий с другими антагонистами и событий на станции для разнообразия контента во время затяжной стадии культа.

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl:
- add: Цель устрашения ниндзи была переименована в запугивание и добавлена в список целей агентов синдиката!
- remove: Эксперименты с динамикой геймплея окончены!
- tweak: Возвращён подсчёт игроков для запуска режима с общего количества на количество готовых!
- tweak: Изменены шансы режимов раундстарт и мидраунд событий. Мажорные мидраунд события были подняты в шансах, в том числе Зомби-режим и Волшебник. Раундстартные режимы ядерных оперативников и выживания подняты в шансах!
- tweak: Голосование за вызов автоматического шаттла эвакуации сдвинуто с 1:20 на 1:50!
