### PR TITLE
martial arts partial fix

### DIFF
--- a/Content.IntegrationTests/SS220/Tests/MartialArts/MartialArtsTest.cs
+++ b/Content.IntegrationTests/SS220/Tests/MartialArts/MartialArtsTest.cs
@@ -74,7 +74,6 @@ public sealed class MartialArtsTest
   - type: Stamina
   - type: Pullable
   - type: Puller
-    pullCooldown: 0
   - type: Fixtures
     fixtures:
       fix1:

--- a/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
@@ -51,16 +51,6 @@ public sealed partial class PullerComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public SoundSpecifier PullSound = new SoundPathSpecifier("/Audio/Effects/thudswoosh.ogg");
-
-    // SS220-PullingCooldown-Start
-    [DataField]
-    [AutoNetworkedField]
-    public TimeSpan LastPullAt = TimeSpan.Zero;
-
-    [DataField]
-    [AutoNetworkedField]
-    public TimeSpan PullCooldown = TimeSpan.FromSeconds(2);
-    // SS220-PullingCooldown-End
 }
 
 public sealed partial class StopPullingAlertEvent : BaseAlertEvent;

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -455,7 +455,7 @@ public sealed class PullingSystem : EntitySystem
         TryStopPull(pullerComp.Pulling.Value, pullableComp, user: player);
     }
 
-    public bool CanPull(EntityUid puller, EntityUid pullableUid, PullerComponent? pullerComp = null, bool ignoreHands = false, bool ignoreCooldown = false) // SS220-Grabs | Add ignoreHands arg
+    public bool CanPull(EntityUid puller, EntityUid pullableUid, PullerComponent? pullerComp = null, bool ignoreHands = false) // SS220-Grabs | Add ignoreHands arg
     {
         if (!Resolve(puller, ref pullerComp, false))
         {
@@ -493,11 +493,6 @@ public sealed class PullingSystem : EntitySystem
         {
             return false;
         }
-
-        // SS220-PullingCooldown-Start
-        if (_timing.CurTime < pullerComp.LastPullAt + pullerComp.PullCooldown && !ignoreCooldown)
-            return false;
-        // SS220-PullingCooldown-End
 
         var getPulled = new BeingPulledAttemptEvent(puller, pullableUid);
         RaiseLocalEvent(pullableUid, getPulled, true);
@@ -573,8 +568,6 @@ public sealed class PullingSystem : EntitySystem
             return false;
 
         // Pulling confirmed
-
-        pullerComp.LastPullAt = _timing.CurTime; // SS220-PullingCooldown
 
         _interaction.DoContactInteraction(pullableUid, pullerUid);
 

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -455,7 +455,7 @@ public sealed class PullingSystem : EntitySystem
         TryStopPull(pullerComp.Pulling.Value, pullableComp, user: player);
     }
 
-    public bool CanPull(EntityUid puller, EntityUid pullableUid, PullerComponent? pullerComp = null, bool ignoreHands = false) // SS220-Grabs | Add ignoreHands arg
+    public bool CanPull(EntityUid puller, EntityUid pullableUid, PullerComponent? pullerComp = null, bool ignoreHands = false, bool ignoreCooldown = false) // SS220-Grabs | Add ignoreHands arg
     {
         if (!Resolve(puller, ref pullerComp, false))
         {
@@ -495,7 +495,7 @@ public sealed class PullingSystem : EntitySystem
         }
 
         // SS220-PullingCooldown-Start
-        if (_timing.CurTime < pullerComp.LastPullAt + pullerComp.PullCooldown)
+        if (_timing.CurTime < pullerComp.LastPullAt + pullerComp.PullCooldown && !ignoreCooldown)
             return false;
         // SS220-PullingCooldown-End
 

--- a/Content.Shared/SS220/Grab/GrabResistanceComponent.cs
+++ b/Content.Shared/SS220/Grab/GrabResistanceComponent.cs
@@ -21,7 +21,7 @@ public sealed partial class GrabResistanceComponent : Component
     public Dictionary<GrabStage, float> CurrentStageBreakoutChance = new();
 
     [DataField, AutoNetworkedField]
-    public TimeSpan FirstBreakoutAttemptDelay = TimeSpan.FromSeconds(0);
+    public TimeSpan FirstBreakoutAttemptDelay = TimeSpan.Zero;
 
     [DataField, AutoNetworkedField]
     public TimeSpan BreakoutAttemptCooldown = TimeSpan.FromSeconds(0.5);

--- a/Content.Shared/SS220/Grab/GrabResistanceComponent.cs
+++ b/Content.Shared/SS220/Grab/GrabResistanceComponent.cs
@@ -21,10 +21,10 @@ public sealed partial class GrabResistanceComponent : Component
     public Dictionary<GrabStage, float> CurrentStageBreakoutChance = new();
 
     [DataField, AutoNetworkedField]
-    public TimeSpan FirstBreakoutAttemptDelay = TimeSpan.FromSeconds(3);
+    public TimeSpan FirstBreakoutAttemptDelay = TimeSpan.FromSeconds(0);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan BreakoutAttemptCooldown = TimeSpan.FromSeconds(30);
+    public TimeSpan BreakoutAttemptCooldown = TimeSpan.FromSeconds(0.5);
 
     [DataField, AutoNetworkedField]
     public TimeSpan LastBreakoutAttemptAt = TimeSpan.Zero;

--- a/Content.Shared/SS220/Grab/GrabResistanceComponent.cs
+++ b/Content.Shared/SS220/Grab/GrabResistanceComponent.cs
@@ -13,18 +13,18 @@ public sealed partial class GrabResistanceComponent : Component
     {
         { GrabStage.Passive, 1.0f },
         { GrabStage.Aggressive, 0.2f },
-        { GrabStage.NeckGrab, 0.02f },
-        { GrabStage.Chokehold, 0.02f }
+        { GrabStage.NeckGrab, 0.015f },
+        { GrabStage.Chokehold, 0.01f }
     };
 
     [DataField, AutoNetworkedField]
     public Dictionary<GrabStage, float> CurrentStageBreakoutChance = new();
 
     [DataField, AutoNetworkedField]
-    public TimeSpan FirstBreakoutAttemptDelay = TimeSpan.Zero;
+    public TimeSpan FirstBreakoutAttemptDelay = TimeSpan.FromSeconds(0.3);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan BreakoutAttemptCooldown = TimeSpan.FromSeconds(0.5);
+    public TimeSpan BreakoutAttemptCooldown = TimeSpan.FromSeconds(1);
 
     [DataField, AutoNetworkedField]
     public TimeSpan LastBreakoutAttemptAt = TimeSpan.Zero;

--- a/Content.Shared/SS220/Grab/SharedGrabSystem.Resistance.cs
+++ b/Content.Shared/SS220/Grab/SharedGrabSystem.Resistance.cs
@@ -92,10 +92,6 @@ public partial class SharedGrabSystem
             return;
 
         // TODO: Once we have predicted randomness delete this for something sane...
-
-        if (_netManager.IsClient)
-            return;
-
         var seed = SharedRandomExtensions.HashCodeCombine(new() { (int)_timing.CurTick.Value, GetNetEntity(grabbable.Owner).Id });
         var rand = new System.Random(seed);
 

--- a/Content.Shared/SS220/Grab/SharedGrabSystem.Resistance.cs
+++ b/Content.Shared/SS220/Grab/SharedGrabSystem.Resistance.cs
@@ -2,11 +2,12 @@
 
 using Content.Shared.Random.Helpers;
 using Robust.Shared.Random;
-
+using Robust.Shared.Network;
 namespace Content.Shared.SS220.Grab;
 
 public partial class SharedGrabSystem
 {
+    [Dependency] private readonly INetManager _netManager = default!;
     private void InitializeResistance()
     {
         SubscribeLocalEvent<GrabResistanceComponent, GrabBreakoutAttemptAlertEvent>(OnBreakoutAttemptAlert);
@@ -91,6 +92,10 @@ public partial class SharedGrabSystem
             return;
 
         // TODO: Once we have predicted randomness delete this for something sane...
+
+        if (_netManager.IsClient)
+            return;
+
         var seed = SharedRandomExtensions.HashCodeCombine(new() { (int)_timing.CurTick.Value, GetNetEntity(grabbable.Owner).Id });
         var rand = new System.Random(seed);
 

--- a/Content.Shared/SS220/Grab/SharedGrabSystem.cs
+++ b/Content.Shared/SS220/Grab/SharedGrabSystem.cs
@@ -3,6 +3,7 @@
 using System.Numerics;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Alert;
+using Content.Shared.Buckle.Components;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
@@ -18,8 +19,10 @@ using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Standing;
+using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
@@ -48,6 +51,7 @@ public abstract partial class SharedGrabSystem : EntitySystem
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly SharedJointSystem _joints = default!;
     [Dependency] private readonly AlertsSystem _alerts = default!;
+    [Dependency] private readonly StandingStateSystem _standing = default!;
 
     protected EntityQuery<GrabbableComponent> _grabbableQuery;
     private EntityQuery<GrabberComponent> _grabberQuery;
@@ -79,6 +83,12 @@ public abstract partial class SharedGrabSystem : EntitySystem
         SubscribeLocalEvent<GrabbableComponent, PickupAttemptEvent>(OnGrabbablePickupAttempt);
 
         SubscribeLocalEvent<GrabberComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);
+
+        SubscribeLocalEvent<GrabberComponent, EntGotInsertedIntoContainerMessage>(OnGrabberContainerInsert);
+        SubscribeLocalEvent<GrabbableComponent, EntGotInsertedIntoContainerMessage>(OnGrabbableContainerInsert);
+
+        SubscribeLocalEvent<GrabberComponent, BuckledEvent>(OnGrabberBuckled);
+        SubscribeLocalEvent<GrabbableComponent, BuckledEvent>(OnGrabbableBuckled);
 
         InitializeResistance();
 
@@ -236,6 +246,36 @@ public abstract partial class SharedGrabSystem : EntitySystem
         ClearJoints((grabber, grabber.Comp), (grabbable, grabbableComp));
     }
 
+    private void OnGrabberContainerInsert(Entity<GrabberComponent> grabber, ref EntGotInsertedIntoContainerMessage args)
+    {
+        if (grabber.Comp.Grabbing is not { } grabbable)
+            return;
+
+        if (!_grabbableQuery.TryComp(grabbable, out var grabbableComp))
+            return;
+
+        BreakGrab((grabbable, grabbableComp));
+    }
+
+    private void OnGrabbableContainerInsert(Entity<GrabbableComponent> grabbable, ref EntGotInsertedIntoContainerMessage args)
+    {
+        BreakGrab((grabbable, grabbable.Comp));
+    }
+
+    private void OnGrabberBuckled(Entity<GrabberComponent> grabber, ref BuckledEvent args)
+    {
+        if (grabber.Comp.Grabbing is not { } grabbable)
+            return;
+        if (!_grabbableQuery.TryComp(grabbable, out var grabbableComp))
+            return;
+        BreakGrab((grabbable, grabbableComp));
+    }
+
+    private void OnGrabbableBuckled(Entity<GrabbableComponent> grabbable, ref BuckledEvent args)
+    {
+        BreakGrab((grabbable, grabbable.Comp));
+    }
+
     #endregion
 
     #region Public API
@@ -292,6 +332,9 @@ public abstract partial class SharedGrabSystem : EntitySystem
             return false;
 
         if (_grabbableQuery.TryComp(grabber, out var grabberGrabbable) && grabberGrabbable.GrabbedBy != null)
+            return false;
+
+        if (_grabberQuery.TryComp(grabbable, out var grabbableAsGrabber) && grabbableAsGrabber.Grabbing != null)
             return false;
 
         if (!_interaction.InRangeAndAccessible(grabber.Owner, grabbable.Owner, grabber.Comp.Range))
@@ -372,7 +415,8 @@ public abstract partial class SharedGrabSystem : EntitySystem
         }
 
         // grab confirmed
-
+        RemComp<KnockedDownComponent>(grabbable);
+        _standing.Stand(grabbable, force: true);
         for (var i = 0; i < grabber.Comp.NeededHands; i++)
         {
             _virtualItem.TrySpawnVirtualItemInHand(grabbable, grabber, out _);
@@ -380,12 +424,10 @@ public abstract partial class SharedGrabSystem : EntitySystem
             if (_virtualItem.TrySpawnVirtualItemInHand(grabber, grabbable, out var virtualItem))
                 EnsureComp<UnremoveableComponent>(virtualItem.Value);
         }
-
         grabber.Comp.Grabbing = grabbable;
         grabbable.Comp.GrabbedBy = grabber;
 
         PlaceGrabbable(grabber, grabbable);
-
         // Create the joint
         var jointId = $"grab_joint_{GetNetEntity(grabbable)}";
         grabber.Comp.GrabJointId = jointId;

--- a/Content.Shared/SS220/Grab/SharedGrabSystem.cs
+++ b/Content.Shared/SS220/Grab/SharedGrabSystem.cs
@@ -123,6 +123,9 @@ public abstract partial class SharedGrabSystem : EntitySystem
 
     private void OnMove(Entity<GrabbableComponent> grabbable, ref MoveInputEvent ev)
     {
+        if (!grabbable.Comp.Grabbed)
+            return;
+
         TryBreakGrab((grabbable, grabbable.Comp));
     }
 
@@ -364,6 +367,9 @@ public abstract partial class SharedGrabSystem : EntitySystem
 
     public void BreakGrab(Entity<GrabbableComponent?> grabbable)
     {
+        if (_timing.ApplyingState)
+            return;
+
         if (!_grabbableQuery.Resolve(grabbable, ref grabbable.Comp))
             return;
 

--- a/Content.Shared/SS220/Grab/SharedGrabSystem.cs
+++ b/Content.Shared/SS220/Grab/SharedGrabSystem.cs
@@ -123,8 +123,7 @@ public abstract partial class SharedGrabSystem : EntitySystem
 
     private void OnMove(Entity<GrabbableComponent> grabbable, ref MoveInputEvent ev)
     {
-        if (grabbable.Comp.GrabStage == GrabStage.Passive)
-            TryBreakGrab((grabbable, grabbable.Comp));
+        TryBreakGrab((grabbable, grabbable.Comp));
     }
 
     private void OnThrown(Entity<GrabbableComponent> ent, ref ThrownEvent args)

--- a/Content.Shared/SS220/Grab/SharedGrabSystem.cs
+++ b/Content.Shared/SS220/Grab/SharedGrabSystem.cs
@@ -341,7 +341,7 @@ public abstract partial class SharedGrabSystem : EntitySystem
             return false;
 
         if (checkCanPull)
-            return _pulling.CanPull(grabber, grabbable, ignoreHands: true, ignoreCooldown: true);
+            return _pulling.CanPull(grabber, grabbable, ignoreHands: true);
 
         return true;
     }

--- a/Content.Shared/SS220/Grab/SharedGrabSystem.cs
+++ b/Content.Shared/SS220/Grab/SharedGrabSystem.cs
@@ -341,7 +341,7 @@ public abstract partial class SharedGrabSystem : EntitySystem
             return false;
 
         if (checkCanPull)
-            return _pulling.CanPull(grabber, grabbable, ignoreHands: true);
+            return _pulling.CanPull(grabber, grabbable, ignoreHands: true, ignoreCooldown: true);
 
         return true;
     }

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Popups;
 using Content.Shared.Projectiles;
 using Content.Shared.Teleportation.Components;
 using Content.Shared.Verbs;
+using Content.Shared.SS220.Grab;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
@@ -136,6 +137,7 @@ public abstract class SharedPortalSystem : EntitySystem
             }
 
             TeleportEntity(ent, subject, Transform(target).Coordinates, target);
+            TeleportGrabPartner(ent, subject, Transform(target).Coordinates, target); // ss220 grab teleport fix
             return;
         }
 
@@ -261,6 +263,33 @@ public abstract class SharedPortalSystem : EntitySystem
         _audio.PlayPredicted(departureSound, ent, subject);
         _audio.PlayPredicted(arrivalSound, subject, subject);
     }
+
+    // ss220 grab teleport fix begin
+    private void TeleportGrabPartner(Entity<PortalComponent> portal, EntityUid subject,
+        EntityCoordinates target, EntityUid? targetEntity)
+    {
+        EntityUid? partner = null;
+        if (TryComp<GrabberComponent>(subject, out var grabberComp) && grabberComp.Grabbing is {} grabbing)
+            partner = grabbing;
+        else if (TryComp<GrabbableComponent>(subject, out var grabbableComp) && grabbableComp.GrabbedBy is {} grabbedBy)
+            partner = grabbedBy;
+
+        if (partner == null)
+            return;
+
+        if (HasComp<PortalTimeoutComponent>(partner.Value))
+            return;
+
+        if (HasComp<PortalComponent>(targetEntity))
+        {
+            var timeout = EnsureComp<PortalTimeoutComponent>(partner.Value);
+            timeout.EnteredPortal = portal;
+            Dirty(partner.Value, timeout);
+        }
+
+        TeleportEntity(portal, partner.Value, target, targetEntity, playSound: false);
+    }
+    // ss220 grab teleport fix end
 
     /// <summary>
     /// Finds a random coordinate within the portal's radius and teleports the subject there.

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
@@ -128,6 +128,9 @@ public abstract class SharedPortalSystem : EntitySystem
             // pick a target and teleport there
             var target = _random.Pick(link.LinkedEntities);
 
+            if (!TryTeleportGrabPartner(ent, subject, Transform(target).Coordinates, target)) // ss220 grab teleport fix
+                return; // ss220 grab teleport fix
+
             if (HasComp<PortalComponent>(target))
             {
                 // if target is a portal, signal that they shouldn't be immediately teleported back
@@ -137,7 +140,6 @@ public abstract class SharedPortalSystem : EntitySystem
             }
 
             TeleportEntity(ent, subject, Transform(target).Coordinates, target);
-            TeleportGrabPartner(ent, subject, Transform(target).Coordinates, target); // ss220 grab teleport fix
             return;
         }
 
@@ -265,20 +267,20 @@ public abstract class SharedPortalSystem : EntitySystem
     }
 
     // ss220 grab teleport fix begin
-    private void TeleportGrabPartner(Entity<PortalComponent> portal, EntityUid subject,
+    private bool TryTeleportGrabPartner(Entity<PortalComponent> portal, EntityUid subject,
         EntityCoordinates target, EntityUid? targetEntity)
     {
         EntityUid? partner = null;
-        if (TryComp<GrabberComponent>(subject, out var grabberComp) && grabberComp.Grabbing is {} grabbing)
+        if (TryComp<GrabberComponent>(subject, out var grabberComp) && grabberComp.Grabbing is { } grabbing)
             partner = grabbing;
-        else if (TryComp<GrabbableComponent>(subject, out var grabbableComp) && grabbableComp.GrabbedBy is {} grabbedBy)
+        else if (TryComp<GrabbableComponent>(subject, out var grabbableComp) && grabbableComp.GrabbedBy is { } grabbedBy)
             partner = grabbedBy;
 
         if (partner == null)
-            return;
+            return true;
 
         if (HasComp<PortalTimeoutComponent>(partner.Value))
-            return;
+            return false;
 
         if (HasComp<PortalComponent>(targetEntity))
         {
@@ -288,6 +290,7 @@ public abstract class SharedPortalSystem : EntitySystem
         }
 
         TeleportEntity(portal, partner.Value, target, targetEntity, playSound: false);
+        return true;
     }
     // ss220 grab teleport fix end
 

--- a/Resources/Prototypes/SS220/MartialArts/corporate_judo.yml
+++ b/Resources/Prototypes/SS220/MartialArts/corporate_judo.yml
@@ -1,7 +1,7 @@
 - type: martialArt
   id: CorporateJudo
   name: martial-art-judo
-  grabDelayCoefficient: 0.5
+  grabDelayCoefficient: 0.3
   effects:
   - !type:WeaponRestrictionMartialArtEffect
     blacklist:
@@ -9,13 +9,13 @@
       - Stunbaton
   sequences:
   - name: martial-art-judo-discombobulate
-    steps: [ Push, Grab ]
+    steps: [ Harm, Push ]
     entry:
       effects:
       - !type:ApplyStatusEffectCombatEffect
         effect: StatusEffectMartialArtSlowdown
-        time: 5
-        timeLimit: 30
+        time: 3
+        timeLimit: 15
         refresh: false
       - !type:ApplyStaminaCombatEffect
         damage: 10

--- a/Resources/Prototypes/SS220/MartialArts/cqc.yml
+++ b/Resources/Prototypes/SS220/MartialArts/cqc.yml
@@ -1,7 +1,7 @@
 - type: martialArt
   id: CloseQuartersCombat
   name: martial-art-cqc
-  grabDelayCoefficient: 0.5
+  grabDelayCoefficient: 0.3
   effects:
   - !type:DisarmChanceMartialArtEffect
     chance: 0.5


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Затяжные правки на боевые искусства

fix: https://github.com/SerbiaStrong-220/space-station-14/issues/4093

- Увеличение коэф. ускорения захвата у владельцев боевых искусств
- Учащения возможности вырывания из захвата для справедливой борьбы
- Изменения приёма "Оглушение" у пояса корп. дзюдо с "Толкание + Захват" на "Удар + Толкание" с последующим изменением замедления с 5 секунд до 3 секунд с максимальным накапливанием до 15 секунд.

В планах пофиксить баг с захватами. ~~Возможно подтянуть выдачу навыка к CQC.~~ 
UPD:
- Добавил события помещения grabber и grabbed в контейнеры и на стулья для сброса захвата
- Добавил обязательное "вставание" жертвы при её захвате
- Добавил обработку телепорта жертвы захвата. Всё ещё проклято.
- Убрал PullingCooldown как более не нужно систему. Ранее она реализована была до появление системы грабов по стадиям и была её "альтернативой - костылей".
- Убрал ограничение на попытку вырываться из граба при помощи движения
- Убрал обработку шансов на клиенте (костыльно, из-за чего въебались попапы, но меня не хватит на разнесение обработчика на сервер и клиент по отдельности)

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl:
- tweak: Изменены задержки для процесса захвата владельцам боевых искусств.
- tweak: Изменён приём "Оглушение" у корпоративного дзюдо. Выполняется теперь через "Атаку + Толкание". Накладывает замедление на 3 секунд заместо 5 секунд, и может накапливаться до 15 секунд заместо 30 секунд.
- tweak: Теперь при попытке взять лежащую жертву в захват - вы её автоматически поднимите на ноги.
- fix: Восстановлена справедливость в попытках выбраться из захвата.
- fix: Теперь захват прерывается, если попытаться во время его действия залезть в мусорку/шкаф/любой "контейнер" или засунуть туда жертву!
- fix: Теперь жертва захвата телепортируется вместе с захватчиком. Однако проклятье 220 всё ещё может настичь.
- fix: Теперь захват прерывается, если попытаться во время его действия посадить жертву на стул/кровать!