### PR TITLE
Node Scanner Display UI fix

### DIFF
--- a/Content.Client/Xenoarchaeology/Ui/NodeScannerDisplay.xaml
+++ b/Content.Client/Xenoarchaeology/Ui/NodeScannerDisplay.xaml
@@ -2,15 +2,17 @@
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     Title="{Loc 'node-scan-display-title'}"
     MinSize="305 180"
-    SetSize="305 180"
     Resizable="False"
     >
+    <!-- SetSize="305 180" - ss220 fix size -->
+
     <BoxContainer Orientation="Vertical" >
         <controls:StripeBack>
             <Label Name="NodeScannerState" HorizontalAlignment="Center" StyleClasses="LabelSubText" Margin="4 0 0 4" />
         </controls:StripeBack>
         <BoxContainer Orientation="Horizontal">
-            <Label Name="NoActiveNodeDataLabel" Text="{Loc 'node-scan-no-data'}" Margin="45 25 0 0" MinHeight="47" />
+            <!-- ss220 fix size -->
+            <Label Name="NoActiveNodeDataLabel" Text="{Loc 'node-scan-no-data'}" Margin="45 25 45 0" MinHeight="47" />
             <GridContainer Name="ActiveNodesList" Columns="4" Rows="2" Visible="True" MinHeight="72" />
         </BoxContainer>
         <controls:StripeBack>


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Поправлены размеры у окна сканера узла артефактов.

**Медиа**
<img width="530" height="259" alt="image" src="https://github.com/user-attachments/assets/334da4da-d3ce-4cb0-bfb3-b63cd07a04f8" />

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl:
- fix: Исправлены размеры окна сканера узла артефакта!

