### PR TITLE
Reducing prices for purchasing resources

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Materials/Sheets/glass.rsi
     state: glass_3
   product: CrateMaterialGlass
-  cost: 6000
+  cost: 1500 #SS220 rollback of Zones's balance
   category: cargoproduct-category-name-materials
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Objects/Materials/Sheets/metal.rsi
     state: steel_3
   product: CrateMaterialSteel
-  cost: 6000
+  cost: 1500 #SS220 rollback of Zones's balance
   category: cargoproduct-category-name-materials
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Materials/Sheets/glass.rsi
     state: glass_3
   product: CrateMaterialGlass
-  cost: 1500 #SS220 rollback of Zones's balance
+  cost: 1500
   category: cargoproduct-category-name-materials
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Objects/Materials/Sheets/metal.rsi
     state: steel_3
   product: CrateMaterialSteel
-  cost: 1500 #SS220 rollback of Zones's balance
+  cost: 1500
   category: cargoproduct-category-name-materials
   group: market
 


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Откатил цены на заказ стали и стекла, которые крутил Зонес. Причина - меньше душки. Заказ на сталь и стекло слишком дорогой, а порой для СБ не хватает банально стали. Получить ее без утилей и разбора техов в гамму трудно. А так, три офицера могут скинуться и купить жизненно необходимый ресурс. 
Старт ПРу дал трекер: https://discord.com/channels/1097181193939730453/1499802863717843087
Так что ПР в какой то мере решит дефицит хотя бы базовых ресурсов, в лице стали (которую культисты едят тоннами)

KemUPD: close: https://github.com/SerbiaStrong-220/DevTeam220/issues/512

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт.

Ссылки на медиа (изображения/видео) будут добавлены в список изменений на дискорд сервере (не более 10 ссылок каждого вида и 10 МБ суммарного веса (для каждого вида)).
Всё что записано между тегами "CLIgnore" будет игнорироваться при отправке списка изменений.-->

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl:
- tweak: Цена на заказ ящика стали и стекла понижена с 6000 кредитов до 1500