### PR TITLE
[FIX] RW roles in access console 

### DIFF
--- a/Resources/Prototypes/SS220/Roles/Jobs/RedWings/redwings_medic.yml
+++ b/Resources/Prototypes/SS220/Roles/Jobs/RedWings/redwings_medic.yml
@@ -20,7 +20,6 @@
   canBeAntag: false
   icon: JobIconRedWingsMedic
   setPreference: false
-  overrideConsoleVisibility: true
   access:
   - Medical
   - Brig

--- a/Resources/Prototypes/SS220/Roles/Jobs/RedWings/redwings_officer.yml
+++ b/Resources/Prototypes/SS220/Roles/Jobs/RedWings/redwings_officer.yml
@@ -17,7 +17,6 @@
   canBeAntag: false
   icon: JobIconRedWingsOfficer
   setPreference: false
-  overrideConsoleVisibility: true
   access:
   - Medical
   - Brig

--- a/Resources/Prototypes/SS220/Roles/Jobs/RedWings/redwings_pilot.yml
+++ b/Resources/Prototypes/SS220/Roles/Jobs/RedWings/redwings_pilot.yml
@@ -17,7 +17,6 @@
   canBeAntag: false
   icon: JobIconRedWingsPilot
   setPreference: false
-  overrideConsoleVisibility: true
   access:
   - Medical
   - Brig


### PR DESCRIPTION

## Описание PR
Полуночный микрофикс ПРа... ГОСПОДИ, КЛЯНУСЬ, Я ПОМНЮ БАГТРЕКЕР НА РОЛИ КРЫЛЬЕВ В КОНСОЛИ ГП, НО НЕ МОГУ НАЙТИ 😭 
Короче были должности РВ в консоли ГП. Теперь не будут

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт.

Ссылки на медиа (изображения/видео) будут добавлены в список изменений на дискорд сервере (не более 10 ссылок каждого вида и 10 МБ суммарного веса (для каждого вида)).
Всё что записано между тегами "CLIgnore" будет игнорироваться при отправке списка изменений.-->

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl:
- fix: Убраны роли Red Wings из консоли доступов