### PR TITLE
Исправление: Не открывалась меню хамелеона в гарнитуре хамелеона

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Ears/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/specific.yml
@@ -24,3 +24,11 @@
       - [ScienceKnowledge, null]
       hiddenName: null
 # SS220-hidden-desc-end
+# SS220 Fix start
+    - type: UserInterface
+      interfaces:
+        enum.ChameleonUiKey.Key:
+          type: ChameleonBoundUserInterface
+        enum.HeadsetKey.Key:
+          type: HeadsetBoundUserInterface
+# SS220 fix end


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Теперь меню "Хамелеон" открывается в гарнитуре хамелеона. Не знаю костылём я сделал или нет, но оно работает.
( fix: #4171 )

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт.

Ссылки на медиа (изображения/видео) будут добавлены в список изменений на дискорд сервере (не более 10 ссылок каждого вида и 10 МБ суммарного веса (для каждого вида)).
Всё что записано между тегами "CLIgnore" будет игнорироваться при отправке списка изменений.-->

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
🆑 Cortez
- fix: Исправлено отображение меню "Хамелеон" в гарнитуре хамелеона