### PR TITLE
Combat Training and Physical Training chances was changed

### DIFF
--- a/Resources/Prototypes/SS220/Experience/Skills/combat_training.yml
+++ b/Resources/Prototypes/SS220/Experience/Skills/combat_training.yml
@@ -9,8 +9,8 @@
     skillDescription: combat-training-initial-desc
   components:
   - type: DisarmChanceChangerSkill
-    disarmByMultiplier: 0.75
-    disarmedMultiplier: 1.25
+    disarmByMultiplier: 0.85
+    disarmedMultiplier: 1.1
 
 - type: skill
   id: CombatTrainingBase
@@ -37,8 +37,8 @@
     skillDescription: combat-training-trained-desc
   components:
   - type: DisarmChanceChangerSkill
-    disarmByMultiplier: 1.5
-    disarmedMultiplier: 0.75
+    disarmByMultiplier: 1.15
+    disarmedMultiplier: 0.9
 
 - type: skill
   id: CombatTrainingProfessional
@@ -51,6 +51,5 @@
     skillDescription: combat-training-professional-desc
   components:
   - type: DisarmChanceChangerSkill
-    disarmByMultiplier: 2
-    disarmedMultiplier: 0.5
-  - type: DisarmBlockSkill
+    disarmByMultiplier: 1.3
+    disarmedMultiplier: 0.8

--- a/Resources/Prototypes/SS220/Experience/Skills/physical_training.yml
+++ b/Resources/Prototypes/SS220/Experience/Skills/physical_training.yml
@@ -9,7 +9,7 @@
     skillDescription: physical-training-initial-desc
   components:
   - type: DisarmOnDamageSkill
-    disarmChance: 0.5
+    disarmChance: 0.4
     damageThreshold: 15.
 
 - type: skill
@@ -23,7 +23,7 @@
     skillDescription: physical-training-base-desc
   components:
   - type: DisarmOnDamageSkill
-    disarmChance: 0.5
+    disarmChance: 0.35
     damageThreshold: 20.
 
 - type: skill


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->
Изменены шансы для навыков Физической и Боевой подготовки.
У боевой подготовки убрана возможность тотально блочить любой шов при максимальной прокачке.

## Изменния До/После физ. подготовки
| Уровень          | Порог урона (было → стало) | Шанс дизарма (было → стало) | Δ шанс |
|------------------|----------------------------|------------------------------|--------|
| Начальный        | ≥15 → ≥15                  | 50% → 40%                    | −10%   |
| Средний          | ≥20 → ≥20                  | 50% → 35%                    | −15%   |
| Продвинутый      | ≥30 → ≥30                  | 30% → 30%                    | 0%     |
| Профессиональный | ≥40 → ≥40                  | 20% → 20%                    | 0%     |

На старте я некоторое время наблюдал за статистикой по количество спущенных очков в этот навык, и он был топ 1-2 по количество. Второй естественно был боевая подготовка, поэтому:

При условии расчёта по формуле: `(множитель-дизарма-атакующего * множитель-быть-дизармнутым-защищающегося) * 0.25` рассчитываются шансы.

## До изменений
| Атакующий \ Защищающийся | Начальный (1.25) | Средний (1) | Продвинутый (0.75) | Профессионал (0.5) |
|--------------------------|------------------|-------------|---------------------|--------------------|
| Начальный (0.75)         | 23.44%           | 18.75%      | 14.06%              | 9.38%              |
| Средний (1)              | 31.25%           | 25.00%      | 18.75%              | 12.50%             |
| Продвинутый (1.5)        | 46.88%           | 37.50%      | 28.13%              | 18.75%             |
| Профессионал (2)         | 62.50%           | 50.00%      | 37.50%              | 25.00%             |
## После изменений
| Атакующий \ Защищающийся | Начальный (1.1) | Средний (1) | Продвинутый (0.9) | Профессионал (0.8) |
|--------------------------|-----------------|-------------|-------------------|--------------------|
| Начальный (0.85)         | 23.38%          | 21.25%      | 19.13%            | 17.00%             |
| Средний (1)              | 27.50%          | 25.00%      | 22.50%            | 20.00%             |
| Продвинутый (1.15)       | 31.63%          | 28.75%      | 25.88%            | 23.00%             |
| Профессионал (1.3)       | 35.75%          | 32.50%      | 29.25%            | 26.00%             |

Фактически - убран большой разрыв между максимальным и минимальным.

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт.

Ссылки на медиа (изображения/видео) будут добавлены в список изменений на дискорд сервере (не более 10 ссылок каждого вида и 10 МБ суммарного веса (для каждого вида)).
Всё что записано между тегами "CLIgnore" будет игнорироваться при отправке списка изменений.-->

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl:
- tweak: Изменены значения шансов у навыков Физическая и Боевая подготовки, подробнее в: [PR](https://github.com/SerbiaStrong-220/space-station-14/pull/4177).