### PR TITLE
[TWEAK] Голиафы дропают кость

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -93,10 +93,10 @@
       amount: 3
     - id: MaterialGoliathHide1
       amount: 3
-#SS220-GoliathDrop-Tweak begin
+    #SS220-GoliathDrop-Tweak begin
     - id: MaterialBones1
       amount: 1
-#SS220-GoliathDrop-Tweak end
+    #SS220-GoliathDrop-Tweak end
 
 - type: entity
   parent: BaseAction

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -93,8 +93,10 @@
       amount: 3
     - id: MaterialGoliathHide1
       amount: 3
-    - id: MaterialBones1 #SS220-GoliathDrop-Tweak
-      amount: 1 #SS220-GoliathDrop-Tweak
+#SS220-GoliathDrop-Tweak begin
+    - id: MaterialBones1
+      amount: 1
+#SS220-GoliathDrop-Tweak end
 
 - type: entity
   parent: BaseAction

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -93,6 +93,8 @@
       amount: 3
     - id: MaterialGoliathHide1
       amount: 3
+    - id: MaterialBones1 #SS220-GoliathDrop-Tweak
+      amount: 1 #SS220-GoliathDrop-Tweak
 
 - type: entity
   parent: BaseAction


### PR DESCRIPTION
## Описание PR
Теперь при разделке голиафа дропается 1 кость которую можно потратить на создание костяной брони.
Трекер: https://discord.com/channels/1097181193939730453/1438269902895976623/1438269902895976623
close: https://github.com/SerbiaStrong-220/DevTeam220/issues/605

**Медиа**

<img width="638" height="296" alt="NVIDIA_Overlay_DqOjYcbTbx" src="https://github.com/user-attachments/assets/55dbb1e9-1488-4375-aa6d-4df77e695fe7" />

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: retrocringe
- tweak: Изменен дроп голиафов, теперь они дропают кость.