### PR TITLE
[FIX] BreakGrab mobState dependency added

### DIFF
--- a/Content.Shared/SS220/Grab/SharedGrabSystem.cs
+++ b/Content.Shared/SS220/Grab/SharedGrabSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Interaction.Components;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Item;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.MouseRotator;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Systems;
@@ -52,6 +53,7 @@ public abstract partial class SharedGrabSystem : EntitySystem
     [Dependency] private readonly SharedJointSystem _joints = default!;
     [Dependency] private readonly AlertsSystem _alerts = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
 
     protected EntityQuery<GrabbableComponent> _grabbableQuery;
     private EntityQuery<GrabberComponent> _grabberQuery;
@@ -386,6 +388,9 @@ public abstract partial class SharedGrabSystem : EntitySystem
 
         grabbable.Comp.GrabbedBy = null;
         Dirty(grabbable);
+
+        if(_mobState.IsDead(grabbable) || _mobState.IsCritical(grabbable))
+            _standing.Down(grabbable);
 
         ClearJoints((grabber, grabberComp), grabbable);
 

--- a/Content.Shared/SS220/Grab/SharedGrabSystem.cs
+++ b/Content.Shared/SS220/Grab/SharedGrabSystem.cs
@@ -389,6 +389,7 @@ public abstract partial class SharedGrabSystem : EntitySystem
         grabbable.Comp.GrabbedBy = null;
         Dirty(grabbable);
 
+        // TODO SS220 This shouldn't be handled here
         if (_mobState.IsIncapacitated(grabbable))
             _standing.Down(grabbable);
 

--- a/Content.Shared/SS220/Grab/SharedGrabSystem.cs
+++ b/Content.Shared/SS220/Grab/SharedGrabSystem.cs
@@ -389,7 +389,7 @@ public abstract partial class SharedGrabSystem : EntitySystem
         grabbable.Comp.GrabbedBy = null;
         Dirty(grabbable);
 
-        if(_mobState.IsDead(grabbable) || _mobState.IsCritical(grabbable))
+        if (_mobState.IsIncapacitated(grabbable))
             _standing.Down(grabbable);
 
         ClearJoints((grabber, grabberComp), grabbable);


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->

Добавил проверку по состоянию сущности (крит/смерть), чтобы кидать их обратно на пол, в случае, если они сами стоять на ногах не могут. На паралитиков не стал добавлять, так как вроде с инвалидными креслами удалили инвалидов, но может быть когда-то в будущем потребуется.

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт.

Ссылки на медиа (изображения/видео) будут добавлены в список изменений на дискорд сервере (не более 10 ссылок каждого вида и 10 МБ суммарного веса (для каждого вида)).
Всё что записано между тегами "CLIgnore" будет игнорироваться при отправке списка изменений.-->

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl:
- fix: Мёртвые или в крит. состоянии больше не будут стоять на ногах после захвата (grab).
