### PR TITLE
Fix smes overcharge

### DIFF
--- a/Content.Shared/Power/EntitySystems/SharedBatterySystem.API.cs
+++ b/Content.Shared/Power/EntitySystems/SharedBatterySystem.API.cs
@@ -84,7 +84,7 @@ public abstract partial class SharedBatterySystem
             return;
 
         var oldValue = GetCharge(ent);
-        var newValue = Math.Clamp(value, 0, ent.Comp.IsOvercharged ? value : ent.Comp.MaxCharge);
+        var newValue = Math.Clamp(value, 0, ent.Comp.IsOvercharged ? value : ent.Comp.MaxCharge); // SS220-add-smes-overcharge
         var delta = newValue - oldValue;
 
         if (delta == 0f)

--- a/Content.Shared/Power/EntitySystems/SharedBatterySystem.API.cs
+++ b/Content.Shared/Power/EntitySystems/SharedBatterySystem.API.cs
@@ -171,7 +171,13 @@ public abstract partial class SharedBatterySystem
         var curTime = _timing.CurTime;
         // We have a constant charge rate, so the charge changes linearly over time.
         var dt = (curTime - ent.Comp.LastUpdate).TotalSeconds;
-        var charge = Math.Clamp(ent.Comp.LastCharge + (float)(dt * ent.Comp.ChargeRate), 0f, ent.Comp.MaxCharge);
+        var charge = Math.Clamp(ent.Comp.LastCharge + (float)(dt * ent.Comp.ChargeRate), 0f, ent.Comp.IsOvercharged ? ent.Comp.StartingCharge : ent.Comp.MaxCharge); // SS220-add-smes-overcharge
+
+        // SS220-add-overcharge-begin
+        if (ent.Comp.IsOvercharged)
+            ent.Comp.IsOvercharged = charge < ent.Comp.MaxCharge;
+        // SS220-add-overcharge-end
+
         return charge;
     }
 

--- a/Content.Shared/Power/EntitySystems/SharedBatterySystem.API.cs
+++ b/Content.Shared/Power/EntitySystems/SharedBatterySystem.API.cs
@@ -84,7 +84,7 @@ public abstract partial class SharedBatterySystem
             return;
 
         var oldValue = GetCharge(ent);
-        var newValue = Math.Clamp(value, 0, ent.Comp.MaxCharge);
+        var newValue = Math.Clamp(value, 0, ent.Comp.IsOvercharged ? value : ent.Comp.MaxCharge);
         var delta = newValue - oldValue;
 
         if (delta == 0f)
@@ -174,8 +174,10 @@ public abstract partial class SharedBatterySystem
         var charge = Math.Clamp(ent.Comp.LastCharge + (float)(dt * ent.Comp.ChargeRate), 0f, ent.Comp.IsOvercharged ? ent.Comp.StartingCharge : ent.Comp.MaxCharge); // SS220-add-smes-overcharge
 
         // SS220-add-overcharge-begin
-        if (ent.Comp.IsOvercharged)
-            ent.Comp.IsOvercharged = charge < ent.Comp.MaxCharge;
+        // Current logic calls GetCharge several times before setting StartingCharge
+        // That's why current logic checks if we were actually charged
+        if (ent.Comp.IsOvercharged && ent.Comp.LastCharge > 0)
+            ent.Comp.IsOvercharged = charge > ent.Comp.MaxCharge;
         // SS220-add-overcharge-end
 
         return charge;


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт.

Ссылки на медиа (изображения/видео) будут добавлены в список изменений на дискорд сервере (не более 10 ссылок каждого вида и 10 МБ суммарного веса (для каждого вида)).
Всё что записано между тегами "CLIgnore" будет игнорироваться при отправке списка изменений.-->

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру и на дискорд сервер, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->

bo bug'o no cl'o