### PR TITLE
[ADD] Магнит сумки для руды у боргов

### DIFF
--- a/Content.Shared/Storage/Components/MagnetPickupComponent.cs
+++ b/Content.Shared/Storage/Components/MagnetPickupComponent.cs
@@ -24,4 +24,7 @@ public sealed partial class MagnetPickupComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite), DataField("range")]
     public float Range = 1f;
+
+    [DataField("workOutOfSlot"), AutoNetworkedField]
+    public bool WorkOutOfSlot = false;
 }

--- a/Content.Shared/Storage/Components/MagnetPickupComponent.cs
+++ b/Content.Shared/Storage/Components/MagnetPickupComponent.cs
@@ -24,7 +24,8 @@ public sealed partial class MagnetPickupComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite), DataField("range")]
     public float Range = 1f;
-
+    //SS220-OreBagBorgMagnet begin
     [DataField("workOutOfSlot"), AutoNetworkedField]
     public bool WorkOutOfSlot = false;
+    //SS220-OreBagBorgMagnet end
 }

--- a/Content.Shared/Storage/Components/MagnetPickupComponent.cs
+++ b/Content.Shared/Storage/Components/MagnetPickupComponent.cs
@@ -25,7 +25,7 @@ public sealed partial class MagnetPickupComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField("range")]
     public float Range = 1f;
     //SS220-OreBagBorgMagnet begin
-    [DataField("worksOutsideSlot"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public bool WorksOutsideSlot = false;
     //SS220-OreBagBorgMagnet end
 }

--- a/Content.Shared/Storage/Components/MagnetPickupComponent.cs
+++ b/Content.Shared/Storage/Components/MagnetPickupComponent.cs
@@ -25,7 +25,7 @@ public sealed partial class MagnetPickupComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField("range")]
     public float Range = 1f;
     //SS220-OreBagBorgMagnet begin
-    [DataField("workOutOfSlot"), AutoNetworkedField]
-    public bool WorkOutOfSlot = false;
+    [DataField("worksOutsideSlot"), AutoNetworkedField]
+    public bool WorksOutsideSlot = false;
     //SS220-OreBagBorgMagnet end
 }

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -48,7 +48,7 @@ public sealed class MagnetPickupSystem : EntitySystem
             comp.NextScan += ScanDelay;
             Dirty(uid, comp);
 
-            //SS220-OreBagBorgMagnet begin
+            // SS220-OreBagBorgMagnet begin
             if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef))
             {
 
@@ -60,7 +60,7 @@ public sealed class MagnetPickupSystem : EntitySystem
             if ((slotDef.SlotFlags & comp.SlotFlags) == 0x0)
                 continue;
             }
-            //SS220-OreBagBorgMagnet end
+            // SS220-OreBagBorgMagnet end
 
             // No space
             if (!_storage.HasSpace((uid, storage)))
@@ -93,8 +93,8 @@ public sealed class MagnetPickupSystem : EntitySystem
                 if (!_storage.Insert(uid, near, out var stacked, storageComp: storage, playSound: !playedSound))
                     continue;
 
-            //SS220-OreBagBorgMagnet begin
-            //Animation of picking up ore from borgs causes the client to crash.
+            // SS220-OreBagBorgMagnet begin
+            // Animation of picking up ore from borgs causes the client to crash.
             if (!comp.WorkOutOfSlot)
             {
                 // Play pickup animation for either the stack entity or the original entity.
@@ -103,7 +103,7 @@ public sealed class MagnetPickupSystem : EntitySystem
                 else
                     _storage.PlayPickupAnimation(near, nearCoords, finalCoords, nearXform.LocalRotation);
             }
-            //SS220-OreBagBorgMagnet end
+            // SS220-OreBagBorgMagnet end
 
                 playedSound = true;
             }

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -1,7 +1,6 @@
 using Content.Shared.Inventory;
 using Content.Shared.Storage.Components;
 using Content.Shared.Whitelist;
-using Content.Shared.Silicons.Borgs.Components; //SS220-OreBagBorgMagnet
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
 
@@ -53,7 +52,7 @@ public sealed class MagnetPickupSystem : EntitySystem
             if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef))
             {
 
-             if (!HasComp<BorgChassisComponent>(xform.ParentUid))
+             if (!comp.WorkOutOfSlot)
                 continue;
             }
             else
@@ -96,7 +95,7 @@ public sealed class MagnetPickupSystem : EntitySystem
 
             //SS220-OreBagBorgMagnet begin
             //Animation of picking up ore from borgs causes the client to crash.
-            if (!HasComp<BorgChassisComponent>(xform.ParentUid))
+            if (!comp.WorkOutOfSlot)
             {
                 // Play pickup animation for either the stack entity or the original entity.
                 if (stacked != null)

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -49,15 +49,13 @@ public sealed class MagnetPickupSystem : EntitySystem
             Dirty(uid, comp);
 
             // SS220-OreBagBorgMagnet begin
-            if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef))
+            if (!comp.WorksOutsideSlot)
             {
 
-             if (!comp.WorkOutOfSlot)
+             if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef))
                 continue;
-            }
-            else
-            {
-            if ((slotDef.SlotFlags & comp.SlotFlags) == 0x0)
+            
+             if ((slotDef.SlotFlags & comp.SlotFlags) == 0x0)
                 continue;
             }
             // SS220-OreBagBorgMagnet end
@@ -93,17 +91,11 @@ public sealed class MagnetPickupSystem : EntitySystem
                 if (!_storage.Insert(uid, near, out var stacked, storageComp: storage, playSound: !playedSound))
                     continue;
 
-            // SS220-OreBagBorgMagnet begin
-            // Animation of picking up ore from borgs causes the client to crash.
-            if (!comp.WorkOutOfSlot)
-            {
                 // Play pickup animation for either the stack entity or the original entity.
                 if (stacked != null)
                     _storage.PlayPickupAnimation(stacked.Value, nearCoords, finalCoords, nearXform.LocalRotation);
                 else
                     _storage.PlayPickupAnimation(near, nearCoords, finalCoords, nearXform.LocalRotation);
-            }
-            // SS220-OreBagBorgMagnet end
 
                 playedSound = true;
             }

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Inventory;
 using Content.Shared.Storage.Components;
 using Content.Shared.Whitelist;
+using Content.Shared.Silicons.Borgs.Components; //SS220-OreBagBorgMagnet
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
 
@@ -48,11 +49,19 @@ public sealed class MagnetPickupSystem : EntitySystem
             comp.NextScan += ScanDelay;
             Dirty(uid, comp);
 
+            //SS220-OreBagBorgMagnet begin
             if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef))
-                continue;
+            {
 
+             if (!HasComp<BorgChassisComponent>(xform.ParentUid))
+                continue;
+            }
+            else
+            {
             if ((slotDef.SlotFlags & comp.SlotFlags) == 0x0)
                 continue;
+            }
+            //SS220-OreBagBorgMagnet end
 
             // No space
             if (!_storage.HasSpace((uid, storage)))
@@ -85,11 +94,17 @@ public sealed class MagnetPickupSystem : EntitySystem
                 if (!_storage.Insert(uid, near, out var stacked, storageComp: storage, playSound: !playedSound))
                     continue;
 
+            //SS220-OreBagBorgMagnet begin
+            //Animation of picking up ore from borgs causes the client to crash.
+            if (!HasComp<BorgChassisComponent>(xform.ParentUid))
+            {
                 // Play pickup animation for either the stack entity or the original entity.
                 if (stacked != null)
                     _storage.PlayPickupAnimation(stacked.Value, nearCoords, finalCoords, nearXform.LocalRotation);
                 else
                     _storage.PlayPickupAnimation(near, nearCoords, finalCoords, nearXform.LocalRotation);
+            }
+            //SS220-OreBagBorgMagnet end
 
                 playedSound = true;
             }

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -39,3 +39,6 @@
     - type: Storage
       grid:
       - 0,0,9,5
+    - type: MagnetPickup
+      workOutOfSlot: true
+

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -39,6 +39,8 @@
     - type: Storage
       grid:
       - 0,0,9,5
+    #SS220-OreBagBorgMagnet begin
     - type: MagnetPickup
       workOutOfSlot: true
+    #SS220-OreBagBorgMagnet end
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -41,6 +41,6 @@
       - 0,0,9,5
     #SS220-OreBagBorgMagnet begin
     - type: MagnetPickup
-      workOutOfSlot: true
+      worksOutsideSlot: true
     #SS220-OreBagBorgMagnet end
 


### PR DESCRIPTION
## Описание PR
* Добавлена проверка на наличие компонента WorksOutsideSlot.
* Компонент добавлен сумке для руды у боргов.
* Компонент убирает необходимость в наличие слота для сумки и дает боргам возможность подбирать руду, так же этот компонент даёт возможность сумке собирать руду если она лежит на земле.

close: https://github.com/SerbiaStrong-220/DevTeam220/issues/642

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl: retrocringe

- add: Сумка для руды у боргов теперь магнитит руду.