### PR TITLE
БольшеНеКричим

### DIFF
--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Speech.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 using Content.Shared.SS220.Speech;// SS220 Chat-Special-Emote
 
 namespace Content.Server.Speech.EntitySystems;
@@ -19,6 +20,7 @@ public sealed class VocalSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly ActionsSystem _actions = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IEntityManager _entities = default!;// SS220 Chat-Special-Emote
 
     public override void Initialize()
@@ -48,6 +50,13 @@ public sealed class VocalSystem : EntitySystem
         targetComp.ScreamId = source.Comp.ScreamId;
         targetComp.Wilhelm = source.Comp.Wilhelm;
         targetComp.WilhelmProbability = source.Comp.WilhelmProbability;
+        targetComp.ScreamAction = source.Comp.ScreamAction;
+        targetComp.ScreamBaseCooldown = source.Comp.ScreamBaseCooldown;
+        targetComp.ScreamCooldownStep = source.Comp.ScreamCooldownStep;
+        targetComp.ScreamCountResetWindow = source.Comp.ScreamCountResetWindow;
+        targetComp.ScreamCount = source.Comp.ScreamCount;
+        targetComp.LastScreamTime = source.Comp.LastScreamTime;
+        targetComp.ScreamCooldownEnd = source.Comp.ScreamCooldownEnd;
         LoadSounds(target, targetComp);
 
         Dirty(target, targetComp);
@@ -79,21 +88,35 @@ public sealed class VocalSystem : EntitySystem
         if (args.Handled || !args.Emote.Category.HasFlag(EmoteCategory.Vocal))
             return;
 
+        if (args.Emote.ID == component.ScreamId)
+        {
+            if (_timing.CurTime < component.ScreamCooldownEnd)
+            {
+                args.Handled = true;
+                return;
+            }
+
+            RegisterScream(uid, component);
+
+            // SS220 Chat-Special-Emote begin
+            if (CheckSpecialSounds(uid, component, args.Emote))
+            {
+                args.Handled = true;
+                return;
+            }
+            // SS220 Chat-Special-Emote end
+
+            args.Handled = TryPlayScreamSound(uid, component);
+            return;
+        }
+
         // SS220 Chat-Special-Emote begin
-        //Will play special emote if it exists
         if(CheckSpecialSounds(uid, component, args.Emote))
         {
             args.Handled = true;
             return;
         }
         // SS220 Chat-Special-Emote end
-
-        // snowflake case for wilhelm scream easter egg
-        if (args.Emote.ID == component.ScreamId)
-        {
-            args.Handled = TryPlayScreamSound(uid, component);
-            return;
-        }
 
         if (component.EmoteSounds is not { } sounds)
             return;
@@ -109,6 +132,27 @@ public sealed class VocalSystem : EntitySystem
 
         _chat.TryEmoteWithChat(uid, component.ScreamId);
         args.Handled = true;
+    }
+
+    private void RegisterScream(EntityUid uid, VocalComponent component)
+    {
+        var now = _timing.CurTime;
+
+        if (now - component.LastScreamTime > component.ScreamCountResetWindow)
+            component.ScreamCount = 0;
+
+        component.ScreamCount++;
+        component.LastScreamTime = now;
+
+        var extra = (component.ScreamCount - 1) * component.ScreamCooldownStep;
+        var cooldown = component.ScreamBaseCooldown + extra;
+        component.ScreamCooldownEnd = now + cooldown;
+
+        if (component.ScreamActionEntity is not { } actionEnt)
+            return;
+
+        _actions.SetUseDelay(actionEnt, cooldown);
+        _actions.SetIfBiggerCooldown(actionEnt, cooldown);
     }
 
     private bool TryPlayScreamSound(EntityUid uid, VocalComponent component)

--- a/Content.Shared/Speech/Components/VocalComponent.cs
+++ b/Content.Shared/Speech/Components/VocalComponent.cs
@@ -42,6 +42,24 @@ public sealed partial class VocalComponent : Component
     [AutoNetworkedField]
     public EntityUid? ScreamActionEntity;
 
+    [DataField]
+    public TimeSpan ScreamBaseCooldown = TimeSpan.FromSeconds(10);
+
+    [DataField]
+    public TimeSpan ScreamCooldownStep = TimeSpan.FromSeconds(15);
+
+    [DataField]
+    public TimeSpan ScreamCountResetWindow = TimeSpan.FromMinutes(10);
+
+    [ViewVariables]
+    public int ScreamCount;
+
+    [ViewVariables]
+    public TimeSpan LastScreamTime;
+
+    [ViewVariables]
+    public TimeSpan ScreamCooldownEnd;
+
     /// <summary>
     ///     Currently loaded emote sounds prototype, based on entity sex.
     ///     Null if no valid prototype for entity sex was found.


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Больше не спамим эмоут крика в любой ситуации.

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт.

Ссылки на медиа (изображения/видео) будут добавлены в список изменений на дискорд сервере (не более 10 ссылок каждого вида и 10 МБ суммарного веса (для каждого вида)).
Всё что записано между тегами "CLIgnore" будет игнорироваться при отправке списка изменений.-->

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl: OperatorXeno
- tweak: Эмоут "Крик" теперь имеет накопительный кулдаун. Каждый каст в течение 10 минут увеличивает кд на 15 секунд. Через 10 минут без использования кд восстанавливается.
- fix: Спам криком через колесо эмоций и команду больше не обходит кулдаун.
