### PR TITLE
[FIX] Хряконата не активировалась

### DIFF
--- a/Resources/Prototypes/SS220/Entities/Objects/Fun/pigrenade.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Fun/pigrenade.yml
@@ -19,6 +19,8 @@
     velocity: 2
   - type: LandAtCursor
   - type: ContainerContainer
+    containers:
+      cluster-payload: !type:Container
   - type: TimerTrigger
     delay: 3.0
     beepSound:
@@ -60,3 +62,6 @@
   components:
   - type: ScatteringGrenade
     fillPrototype: MobPig
+  - type: ContainerContainer
+    containers:
+      cluster-payload: !type:Container

--- a/Resources/Prototypes/SS220/Entities/Objects/Fun/pigrenade.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Fun/pigrenade.yml
@@ -1,7 +1,7 @@
 # © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
 
 - type: entity
-  parent: ScatteringGrenadeBase
+  parent: TimerGrenadeBase
   id: Pigrenade
   name: pigrenade
   description: Grenade that creates a small but devastating oink.
@@ -19,6 +19,7 @@
     velocity: 2
   - type: LandAtCursor
   - type: TimerTrigger
+    delay: 3
     beepSound:
       path: "/Audio/SS220/Effects/pigrenade/hru.ogg"
       params:

--- a/Resources/Prototypes/SS220/Entities/Objects/Fun/pigrenade.yml
+++ b/Resources/Prototypes/SS220/Entities/Objects/Fun/pigrenade.yml
@@ -18,8 +18,9 @@
     capacity: 6
     velocity: 2
   - type: LandAtCursor
+  - type: ContainerContainer
   - type: TimerTrigger
-    delay: 3
+    delay: 3.0
     beepSound:
       path: "/Audio/SS220/Effects/pigrenade/hru.ogg"
       params:


### PR DESCRIPTION
## Описание PR
Хряконату после апстрима нельзя было активировать, теперь можно.

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: retrocringe

- fix: Хряконата снова работает.