### PR TITLE
[TWEAK] Трость НТРа в двух руках не наносила урон

### DIFF
--- a/Resources/Prototypes/SS220/expensive_cane.yml
+++ b/Resources/Prototypes/SS220/expensive_cane.yml
@@ -22,5 +22,5 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: -13
+        Blunt: 4
   - type: MobilityAid


### PR DESCRIPTION
## Описание PR
close: https://github.com/SerbiaStrong-220/space-station-14/issues/4291
Сам я не уверен что это был баг по двум причинам.
1 - урон по стамине наносится только если взять трость в 2 руки в размере 38.
2 - был прописан отрицательный модификатор урона когда трость находится в двух руках. Из 13 урона изначальных вычиталось 13, будто бы так и задумывалось.

Добавил +4 урона когда трость удерживают в двух руках, суммарный урон 17. Всё таки кукла держит её в двух руках и удар должен быть сильнее.

<!--CLIgnore-->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: retrocringe

- tweak: Трость НТРа в двух руках теперь наносит 17 суммарного blunt урона.