### PR TITLE
[TWEAK] Мешок для тела и разрушаемость

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -84,6 +84,28 @@
       paper_label: !type:ContainerSlot
   - type: StaticPrice
     price: 50
+  #SS220-BodyBagDamageable begin
+  - type: Damageable
+    damageContainer: Inorganic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 20
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          path: /Audio/Effects/poster_broken.ogg
+          params:
+            volume: -4
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetPlastic1:
+            min: 1
+            max: 2
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    #SS220-BodyBagDamageable end
 
 - type: entity
   id: BodyBagFolded


### PR DESCRIPTION
## Описание PR
Мешок для тела нельзя было разрушить.
Жнец при всем желании не мог сломать мешок и насытиться тем что внутри, так же это могло быть абузом для того чтобы прятаться от жнеца через ползание залезая в мешок.
Теперь жнец разрушает мешок за 2 удара в первой стадии, мешок рвется с таким же звуком как постер, дропает 1-2 пластика, после разрушения тело появляется.

<!--CLIgnore-->
**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
**Изменения**

:cl: retrocringe
- tweak: Мешок для тела теперь разрушается.