### PR TITLE
ФИКС: Выключение персонального щита аннулирует замедление

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -155,6 +155,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.6
     sprintModifier: 0.6
+    requireActivated: false #ss220 shield fix
   - type: HeldSpeedModifier
   - type: Item
     size: Ginormous


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Выключение персонального щита больше не аннулирует замедление
(fix:#4310)

**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт.

Ссылки на медиа (изображения/видео) будут добавлены в список изменений на дискорд сервере (не более 10 ссылок каждого вида и 10 МБ суммарного веса (для каждого вида)).
Всё что записано между тегами "CLIgnore" будет игнорироваться при отправке списка изменений.-->

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
🆑 Cortez
- fix: Выключение персонального щита теперь не аннулирует замедление