### PR TITLE
[FIX] Бнууй проходя сквозь шлюзы активировал их

### DIFF
--- a/Resources/Prototypes/SS220/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/SS220/Entities/Mobs/NPCs/pets.yml
@@ -233,5 +233,5 @@
       path: /Audio/SS220/Animals/bnuuy_squeak_2.ogg
   - type: Tag
     tags:
-    - Hamster
+    - StunImmune
 

--- a/Resources/Prototypes/SS220/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/SS220/Entities/Mobs/NPCs/pets.yml
@@ -231,3 +231,7 @@
     interactSuccessSpawn: EffectHearts
     interactSuccessSound:
       path: /Audio/SS220/Animals/bnuuy_squeak_2.ogg
+  - type: Tag
+    tags:
+    - Hamster
+


### PR DESCRIPTION
## Описание PR
Бнууй при проходе через шлюз, а делает он это свободно как хомяк или мышь, триггерил его и открывал.
Перезаписал Tag и убрал лишний DoorBumpOpener, теперь он ровно как хомяк проходя сквозь шлюз не триггерит его.

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: retrocringe
- fix: Бнууй проходя через шлюз больше не триггерит его.