### PR TITLE
[ADD] ТТС материнскому ядру ксеноборгов

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
@@ -243,6 +243,10 @@
   - type: ShowElectrocutionHUD
   - type: PowerMonitoringCableNetworks
   - type: RadarConsole
+  #SS220-AddMotherShipTTS begin
+  - type: TTS
+    voice: glados
+  #SS220-AddMotherShipTTS end
 
 - type: entity
   parent: BaseAGhostAction


### PR DESCRIPTION
## Описание PR
Ядро ксеноборгов было немым, но теперь в прототипе выдается голос glados.
Проверить звучание на локалке не смог, но в прототипе выдается то что задано.
close: https://github.com/SerbiaStrong-220/DevTeam220/issues/810
**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: retrocringe
- add: Ядро ксеноборгов теперь имеет голос glados.