### PR TITLE
Make invis great again

### DIFF
--- a/Content.Client/Stealth/StealthSystem.cs
+++ b/Content.Client/Stealth/StealthSystem.cs
@@ -94,6 +94,7 @@ public sealed class StealthSystem : SharedStealthSystem
 
         _shader.SetParameter("reference", reference);
         _shader.SetParameter("visibility", visibility);
+        _shader.SetParameter("shimmer_scale", component.ShimmerScale); // SS220 invis buff
 
         visibility = MathF.Max(0, visibility);
         _sprite.SetColor((uid, args.Sprite), new Color(visibility, visibility, 1, 1));

--- a/Content.Shared/Ninja/Components/SpaceNinjaComponent.cs
+++ b/Content.Shared/Ninja/Components/SpaceNinjaComponent.cs
@@ -55,7 +55,7 @@ public sealed partial class SpaceNinjaComponent : Component
     /// </summary>
     [DataField]
     public ProtoId<AlertPrototype> SuitPowerAlert = "SuitPower";
-    
+
     // SS220 invis buff start
     /// <summary>
     /// Minimum health damage taken in a single hit to disable invis

--- a/Content.Shared/Ninja/Components/SpaceNinjaComponent.cs
+++ b/Content.Shared/Ninja/Components/SpaceNinjaComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Alert;
+using Content.Shared.FixedPoint;
 using Content.Shared.Ninja.Systems;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -54,4 +55,12 @@ public sealed partial class SpaceNinjaComponent : Component
     /// </summary>
     [DataField]
     public ProtoId<AlertPrototype> SuitPowerAlert = "SuitPower";
+    
+    // SS220 invis buff start
+    /// <summary>
+    /// Minimum health damage taken in a single hit to disable invis
+    /// </summary>
+    [DataField]
+    public FixedPoint2 RevealDamageThreshold = 8;
 }
+    // SS220 invis buff end

--- a/Content.Shared/Ninja/Components/SpaceNinjaComponent.cs
+++ b/Content.Shared/Ninja/Components/SpaceNinjaComponent.cs
@@ -62,5 +62,5 @@ public sealed partial class SpaceNinjaComponent : Component
     /// </summary>
     [DataField]
     public FixedPoint2 RevealDamageThreshold = 8;
-}
     // SS220 invis buff end
+}

--- a/Content.Shared/Ninja/Systems/SharedSpaceNinjaSystem.cs
+++ b/Content.Shared/Ninja/Systems/SharedSpaceNinjaSystem.cs
@@ -85,15 +85,16 @@ public abstract class SharedSpaceNinjaSystem : EntitySystem
     {
         TryRevealNinja(ent, disable: true);
     }
-
+    // SS220 invis buff start
     /// <summary>
-    /// Handle revealing ninja if cloaked when taking health damage (gunfire).
+    /// Handle revealing ninja if cloaked when taking amount of health damage.
     /// </summary>
     private void OnNinjaDamaged(Entity<SpaceNinjaComponent> ent, ref DamageChangedEvent args)
     {
-        if (args.DamageIncreased)
+        if (args.DamageIncreased && args.DamageDelta is { } delta && delta.GetTotal() >= ent.Comp.RevealDamageThreshold)
             TryRevealNinja(ent, disable: true);
     }
+    // SS220 invis buff end
 
     /// <summary>
     /// Handle revealing ninja if cloaked when attacking.

--- a/Content.Shared/Ninja/Systems/SharedSpaceNinjaSystem.cs
+++ b/Content.Shared/Ninja/Systems/SharedSpaceNinjaSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Damage.Systems;
 using Content.Shared.Ninja.Components;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Events;
@@ -21,6 +22,7 @@ public abstract class SharedSpaceNinjaSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<SpaceNinjaComponent, AttackedEvent>(OnNinjaAttacked);
+        SubscribeLocalEvent<SpaceNinjaComponent, DamageChangedEvent>(OnNinjaDamaged); // SS220 reveal on health damage
         SubscribeLocalEvent<SpaceNinjaComponent, MeleeAttackEvent>(OnNinjaAttack);
         SubscribeLocalEvent<SpaceNinjaComponent, ShotAttemptedEvent>(OnShotAttempted);
     }
@@ -82,6 +84,15 @@ public abstract class SharedSpaceNinjaSystem : EntitySystem
     private void OnNinjaAttacked(Entity<SpaceNinjaComponent> ent, ref AttackedEvent args)
     {
         TryRevealNinja(ent, disable: true);
+    }
+
+    /// <summary>
+    /// Handle revealing ninja if cloaked when taking health damage (gunfire).
+    /// </summary>
+    private void OnNinjaDamaged(Entity<SpaceNinjaComponent> ent, ref DamageChangedEvent args)
+    {
+        if (args.DamageIncreased)
+            TryRevealNinja(ent, disable: true);
     }
 
     /// <summary>

--- a/Content.Shared/Stealth/Components/StealthComponent.cs
+++ b/Content.Shared/Stealth/Components/StealthComponent.cs
@@ -80,15 +80,15 @@ public sealed class StealthComponentState : ComponentState
     public readonly float Visibility;
     public readonly TimeSpan? LastUpdated;
     public readonly bool Enabled;
-    public readonly float MinVisibility; // SS220
-    public readonly float MaxVisibility; // SS220
+    public readonly float MinVisibility; // SS220 invis buff
+    public readonly float MaxVisibility; // SS220 invis buff
 
-    public StealthComponentState(float stealthLevel, TimeSpan? lastUpdated, bool enabled, float minVisibility, float maxVisibility)
+    public StealthComponentState(float stealthLevel, TimeSpan? lastUpdated, bool enabled, float minVisibility, float maxVisibility) // SS220 invis buff
     {
         Visibility = stealthLevel;
         LastUpdated = lastUpdated;
         Enabled = enabled;
-        MinVisibility = minVisibility; // SS220
-        MaxVisibility = maxVisibility; // SS220
+        MinVisibility = minVisibility; // SS220 invis buff
+        MaxVisibility = maxVisibility; // SS220 invis buff
     }
 }

--- a/Content.Shared/Stealth/Components/StealthComponent.cs
+++ b/Content.Shared/Stealth/Components/StealthComponent.cs
@@ -73,11 +73,13 @@ public sealed partial class StealthComponent : Component
     [DataField("examinedDesc")]
     public string ExaminedDesc = "stealth-visual-effect";
 
+    // SS220 invis buff begin
     /// <summary>
     /// Multiplier for the shimmer strength in the stealth shader.
     /// </summary>
     [DataField]
-    public float ShimmerScale = 1f; // SS220 invis buff
+    public float ShimmerScale = 1f;
+    // SS220 invis buff end
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Stealth/Components/StealthComponent.cs
+++ b/Content.Shared/Stealth/Components/StealthComponent.cs
@@ -72,6 +72,12 @@ public sealed partial class StealthComponent : Component
     /// </summary>
     [DataField("examinedDesc")]
     public string ExaminedDesc = "stealth-visual-effect";
+
+    /// <summary>
+    /// Multiplier for the shimmer strength in the stealth shader.
+    /// </summary>
+    [DataField]
+    public float ShimmerScale = 1f; // SS220 invis buff
 }
 
 [Serializable, NetSerializable]
@@ -82,13 +88,15 @@ public sealed class StealthComponentState : ComponentState
     public readonly bool Enabled;
     public readonly float MinVisibility; // SS220 invis buff
     public readonly float MaxVisibility; // SS220 invis buff
+    public readonly float ShimmerScale; // SS220 invis buff
 
-    public StealthComponentState(float stealthLevel, TimeSpan? lastUpdated, bool enabled, float minVisibility, float maxVisibility) // SS220 invis buff
+    public StealthComponentState(float stealthLevel, TimeSpan? lastUpdated, bool enabled, float minVisibility, float maxVisibility, float shimmerScale) // SS220 invis buff
     {
         Visibility = stealthLevel;
         LastUpdated = lastUpdated;
         Enabled = enabled;
         MinVisibility = minVisibility; // SS220 invis buff
         MaxVisibility = maxVisibility; // SS220 invis buff
+        ShimmerScale = shimmerScale; // SS220 invis buff
     }
 }

--- a/Content.Shared/Stealth/Components/StealthComponent.cs
+++ b/Content.Shared/Stealth/Components/StealthComponent.cs
@@ -80,11 +80,15 @@ public sealed class StealthComponentState : ComponentState
     public readonly float Visibility;
     public readonly TimeSpan? LastUpdated;
     public readonly bool Enabled;
+    public readonly float MinVisibility; // SS220
+    public readonly float MaxVisibility; // SS220
 
-    public StealthComponentState(float stealthLevel, TimeSpan? lastUpdated, bool enabled)
+    public StealthComponentState(float stealthLevel, TimeSpan? lastUpdated, bool enabled, float minVisibility, float maxVisibility)
     {
         Visibility = stealthLevel;
         LastUpdated = lastUpdated;
         Enabled = enabled;
+        MinVisibility = minVisibility; // SS220
+        MaxVisibility = maxVisibility; // SS220
     }
 }

--- a/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
+++ b/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
@@ -6,19 +6,19 @@ namespace Content.Shared.Stealth.Components
     ///     When added to an entity with stealth component, this component will change the visibility
     ///     based on the entity's (lack of) movement.
     /// </summary>
-    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState] // SS220 invis buff
     public sealed partial class StealthOnMoveComponent : Component
     {
         /// <summary>
         /// Rate that effects how fast an entity's visibility passively changes.
         /// </summary>
-        [DataField("passiveVisibilityRate"), AutoNetworkedField] // SS220 invis sync
+        [DataField("passiveVisibilityRate"), AutoNetworkedField] // SS220 invis buff
         public float PassiveVisibilityRate = -0.15f;
 
         /// <summary>
         /// Rate for movement induced visibility changes. Scales with distance moved.
         /// </summary>
-        [DataField("movementVisibilityRate"), AutoNetworkedField] // SS220 invis sync
+        [DataField("movementVisibilityRate"), AutoNetworkedField] // SS220 invis buff
         public float MovementVisibilityRate = 0.2f;
     }
 }

--- a/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
+++ b/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
@@ -6,19 +6,19 @@ namespace Content.Shared.Stealth.Components
     ///     When added to an entity with stealth component, this component will change the visibility
     ///     based on the entity's (lack of) movement.
     /// </summary>
-    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState] // SS220 invis buff
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState] // SS220 invis buff (added [AutoGenerateComponentState])
     public sealed partial class StealthOnMoveComponent : Component
     {
         /// <summary>
         /// Rate that effects how fast an entity's visibility passively changes.
         /// </summary>
-        [DataField("passiveVisibilityRate"), AutoNetworkedField] // SS220 invis buff
+        [DataField("passiveVisibilityRate"), AutoNetworkedField] // SS220 invis buff (added [AutoNetworkedField])
         public float PassiveVisibilityRate = -0.15f;
 
         /// <summary>
         /// Rate for movement induced visibility changes. Scales with distance moved.
         /// </summary>
-        [DataField("movementVisibilityRate"), AutoNetworkedField] // SS220 invis buff
+        [DataField("movementVisibilityRate"), AutoNetworkedField] // SS220 invis buff (added [AutoNetworkedField])
         public float MovementVisibilityRate = 0.2f;
     }
 }

--- a/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
+++ b/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
@@ -6,19 +6,19 @@ namespace Content.Shared.Stealth.Components
     ///     When added to an entity with stealth component, this component will change the visibility
     ///     based on the entity's (lack of) movement.
     /// </summary>
-    [RegisterComponent, NetworkedComponent]
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
     public sealed partial class StealthOnMoveComponent : Component
     {
         /// <summary>
         /// Rate that effects how fast an entity's visibility passively changes.
         /// </summary>
-        [DataField("passiveVisibilityRate")]
+        [DataField("passiveVisibilityRate"), AutoNetworkedField] // SS220 invis sync
         public float PassiveVisibilityRate = -0.15f;
 
         /// <summary>
         /// Rate for movement induced visibility changes. Scales with distance moved.
         /// </summary>
-        [DataField("movementVisibilityRate")]
+        [DataField("movementVisibilityRate"), AutoNetworkedField] // SS220 invis sync
         public float MovementVisibilityRate = 0.2f;
     }
 }

--- a/Content.Shared/Stealth/SharedStealthSystem.cs
+++ b/Content.Shared/Stealth/SharedStealthSystem.cs
@@ -98,7 +98,7 @@ public abstract class SharedStealthSystem : EntitySystem
 
     private void OnStealthGetState(EntityUid uid, StealthComponent component, ref ComponentGetState args)
     {
-        args.State = new StealthComponentState(component.LastVisibility, component.LastUpdated, component.Enabled);
+        args.State = new StealthComponentState(component.LastVisibility, component.LastUpdated, component.Enabled, component.MinVisibility, component.MaxVisibility);
     }
 
     private void OnStealthHandleState(EntityUid uid, StealthComponent component, ref ComponentHandleState args)
@@ -109,6 +109,8 @@ public abstract class SharedStealthSystem : EntitySystem
         SetEnabled(uid, cast.Enabled, component);
         component.LastVisibility = cast.Visibility;
         component.LastUpdated = cast.LastUpdated;
+        component.MinVisibility = cast.MinVisibility;
+        component.MaxVisibility = cast.MaxVisibility;
     }
 
     private void OnMove(EntityUid uid, StealthOnMoveComponent component, ref MoveEvent args)

--- a/Content.Shared/Stealth/SharedStealthSystem.cs
+++ b/Content.Shared/Stealth/SharedStealthSystem.cs
@@ -98,7 +98,7 @@ public abstract class SharedStealthSystem : EntitySystem
 
     private void OnStealthGetState(EntityUid uid, StealthComponent component, ref ComponentGetState args)
     {
-        args.State = new StealthComponentState(component.LastVisibility, component.LastUpdated, component.Enabled, component.MinVisibility, component.MaxVisibility);
+        args.State = new StealthComponentState(component.LastVisibility, component.LastUpdated, component.Enabled, component.MinVisibility, component.MaxVisibility); // SS220 invis buff
     }
 
     private void OnStealthHandleState(EntityUid uid, StealthComponent component, ref ComponentHandleState args)
@@ -109,8 +109,8 @@ public abstract class SharedStealthSystem : EntitySystem
         SetEnabled(uid, cast.Enabled, component);
         component.LastVisibility = cast.Visibility;
         component.LastUpdated = cast.LastUpdated;
-        component.MinVisibility = cast.MinVisibility;
-        component.MaxVisibility = cast.MaxVisibility;
+        component.MinVisibility = cast.MinVisibility; // SS220 invis buff
+        component.MaxVisibility = cast.MaxVisibility; // SS220 invis buff
     }
 
     private void OnMove(EntityUid uid, StealthOnMoveComponent component, ref MoveEvent args)

--- a/Content.Shared/Stealth/SharedStealthSystem.cs
+++ b/Content.Shared/Stealth/SharedStealthSystem.cs
@@ -98,7 +98,7 @@ public abstract class SharedStealthSystem : EntitySystem
 
     private void OnStealthGetState(EntityUid uid, StealthComponent component, ref ComponentGetState args)
     {
-        args.State = new StealthComponentState(component.LastVisibility, component.LastUpdated, component.Enabled, component.MinVisibility, component.MaxVisibility); // SS220 invis buff
+        args.State = new StealthComponentState(component.LastVisibility, component.LastUpdated, component.Enabled, component.MinVisibility, component.MaxVisibility, component.ShimmerScale); // SS220 invis buff
     }
 
     private void OnStealthHandleState(EntityUid uid, StealthComponent component, ref ComponentHandleState args)
@@ -111,6 +111,7 @@ public abstract class SharedStealthSystem : EntitySystem
         component.LastUpdated = cast.LastUpdated;
         component.MinVisibility = cast.MinVisibility; // SS220 invis buff
         component.MaxVisibility = cast.MaxVisibility; // SS220 invis buff
+        component.ShimmerScale = cast.ShimmerScale; // SS220 invis buff
     }
 
     private void OnMove(EntityUid uid, StealthOnMoveComponent component, ref MoveEvent args)

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -193,6 +193,7 @@
       minVisibility: 0.05
       maxVisibility: 1
       lastVisibility: 1
+      shimmerScale: 0.25
     - type: StealthOnMove
       passiveVisibilityRate: -0.475
       movementVisibilityRate: 0

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -189,12 +189,14 @@
     parent: true
     components:
     - type: Stealth
-      minVisibility: 0.05 # SS220 faint silhouette
-      maxVisibility: 1  # SS220
-      lastVisibility: 1 # SS220 so it can fade slowly
+  # SS220 invis buff begin
+      minVisibility: 0.05
+      maxVisibility: 1
+      lastVisibility: 1
     - type: StealthOnMove
-      passiveVisibilityRate: -0.475 # ~2 fade
-      movementVisibilityRate: 0 # movement dont reveal ninja
+      passiveVisibilityRate: -0.475
+      movementVisibilityRate: 0
+  # SS220 invis buff end
   - type: PowerCellDraw
     drawRate: 1.8 # 200 seconds on the default cell
   - type: ToggleCellDraw

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -189,9 +189,12 @@
     parent: true
     components:
     - type: Stealth
-      minVisibility: -1 # SS220 Revert Ninja Stealth by #1075. Fix #1575 begin
-      maxVisibility: -1
-      lastVisibility: 0 # SS220 Revert Ninja Stealth by #1075. Fix #1575 end
+      minVisibility: 0.05 # SS220 faint silhouette
+      maxVisibility: 1  # SS220
+      lastVisibility: 1 # SS220 so it can fade slowly
+    - type: StealthOnMove
+      passiveVisibilityRate: -0.475 # ~2 fade
+      movementVisibilityRate: 0 # movement dont reveal ninja
   - type: PowerCellDraw
     drawRate: 1.8 # 200 seconds on the default cell
   - type: ToggleCellDraw

--- a/Resources/Textures/Shaders/stealth.swsl
+++ b/Resources/Textures/Shaders/stealth.swsl
@@ -6,6 +6,7 @@ uniform mediump vec2 reference;
 
 const mediump float time_scale = 0.25;
 const mediump float distance_scale = 0.125;
+const mediump float shimmer_scale = 0.25; // SS220 added multiplier for easy tweaking and not touch actual formula
 
 void fragment() {
 
@@ -22,7 +23,7 @@ void fragment() {
     // visualize distortion via:
     // COLOR = vec4(w,w,w,1.0);
 
-    w *= (3.0 + visibility * 2.0);
+    w *= (3 + visibility * 2.0) * shimmer_scale; // SS220
 
     highp vec4 background = zTextureSpec(SCREEN_TEXTURE, ( FRAGCOORD.xy + vec2(w) ) * SCREEN_PIXEL_SIZE );
 

--- a/Resources/Textures/Shaders/stealth.swsl
+++ b/Resources/Textures/Shaders/stealth.swsl
@@ -23,7 +23,7 @@ void fragment() {
     // visualize distortion via:
     // COLOR = vec4(w,w,w,1.0);
 
-    w *= (3 + visibility * 2.0) * shimmer_scale; // SS220
+    w *= (3.0 + visibility * 2.0) * shimmer_scale; // SS220
 
     highp vec4 background = zTextureSpec(SCREEN_TEXTURE, ( FRAGCOORD.xy + vec2(w) ) * SCREEN_PIXEL_SIZE );
 

--- a/Resources/Textures/Shaders/stealth.swsl
+++ b/Resources/Textures/Shaders/stealth.swsl
@@ -3,10 +3,10 @@ light_mode unshaded;
 uniform sampler2D SCREEN_TEXTURE;
 uniform highp float visibility; // number between -1 and 1
 uniform mediump vec2 reference;
+uniform mediump float shimmer_scale; // SS220 cloak shimmer strength, set from StealthComponent
 
 const mediump float time_scale = 0.25;
 const mediump float distance_scale = 0.125;
-const mediump float shimmer_scale = 0.25; // SS220 added multiplier for easy tweaking and not touch actual formula
 
 void fragment() {
 


### PR DESCRIPTION
Так как РП инвиза нет (и не должно быть) 
Возвращён нормальный инвиз. 
Ниндзя теперь снова плавно красиво уходит в инвиз.

Было: 


https://github.com/user-attachments/assets/41322c5b-79b9-487a-bbe9-3326f995712c


Стало:

https://github.com/user-attachments/assets/41e590d9-6ff5-4a71-8304-520f9cd33d02




<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

:cl: Lanc

- tweak: Теперь маскировка ниндзи не скрывает его полностью, оставляя еле заметный силуэт.
- tweak: Значительно снижена интенсивность (заметность) блюра, которым покрыта маскировка ниндзи.
- fix: Ниндзя снова плавно уходит в инвиз а не мгновенно.
- fix: Ниндзя теперь теряет инвиз при получении урона не только в мили но и от взрывов/пуль/лазеров.
