### PR TITLE
[FIX] Одинаковые рецепты булочки и сосиски в тесте

### DIFF
--- a/Resources/Prototypes/SS220/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/SS220/Recipes/Cooking/meal_recipes.yml
@@ -487,7 +487,7 @@
   time: 5
   group: Breads
   reagents:
-    TableSalt: 5
+    TableSalt: 1
   solids:
     FoodDoughSlice: 1
     FoodMeatCutlet: 1

--- a/Resources/Prototypes/SS220/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/SS220/Recipes/Cooking/meal_recipes.yml
@@ -486,6 +486,8 @@
   result: FoodBakedBunMeat
   time: 5
   group: Breads
+  reagents:
+    TableSalt: 5
   solids:
     FoodDoughSlice: 1
     FoodMeatCutlet: 1


### PR DESCRIPTION
## Описание PR
Когда делал PR для блюд без рецептов сделал одинаковый для булки и сосиски в тесте, из-за чего могло готовиться только что-то одно.
Добавил щепотку соли в рецепт мясной булки чтобы рецепты отличались и можно было нормально готовить то и то.

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: retrocringe
- fix: Теперь рецепт сосиски в тесте и мясной булочки отличаются.