### PR TITLE
[FIX] Швабра JR выдавалась всем подряд

### DIFF
--- a/Resources/Prototypes/SS220/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/SS220/Loadouts/loadout_groups.yml
@@ -924,6 +924,7 @@
 - type: loadoutGroup
   id: JanitorEquipment
   name: loadout-group-janitor-equipment
+  minLimit: 0
   loadouts:
   - JRMopItem
   # Уборщик (Конец)


### PR DESCRIPTION
## Описание PR
Из-за того что в группе лодаута не был указан минимальный лимит, швабра выдавалась вообще всем, даже у кого не было наиграно нужное количество времени, также её нельзя было убрать.

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: retrocringe

- fix: Швабра JR за время теперь не выдается всем подряд и её можно убрать из лодаута.