### PR TITLE
[ADD] Техобслуживание мим, клоун и музыкант.

### DIFF
--- a/Resources/Locale/ru-RU/ss220/prototypes/entities/structures/doors/airlocks/access.ftl
+++ b/Resources/Locale/ru-RU/ss220/prototypes/entities/structures/doors/airlocks/access.ftl
@@ -254,3 +254,7 @@ ent-AirlockMimeMaintLocked = { ent-AirlockMaint }
     .suffix = { ent-AirlockGlassMimeLocked.suffix }
     .desc = { ent-AirlockMaint.desc }
 
+ent-AirlockMusicianMaintLocked = { ent-AirlockMaint }
+    .suffix = { ent-AirlockGlassMusicianLocked.suffix }
+    .desc = { ent-AirlockMaint.desc }
+

--- a/Resources/Locale/ru-RU/ss220/prototypes/entities/structures/doors/airlocks/access.ftl
+++ b/Resources/Locale/ru-RU/ss220/prototypes/entities/structures/doors/airlocks/access.ftl
@@ -246,3 +246,10 @@ ent-AirlockClownLocked = { ent-AirlockClown }
     .suffix = Клоун, Закрыт
     .desc = { ent-AirlockServiceGlassLocked.desc }
 
+ent-AirlockClownMaintLocked = { ent-AirlockMaint }
+    .suffix = Клоун, Закрыт
+    .desc = { ent-AirlockMaint.desc }
+
+ent-AirlockMimeMaintLocked = { ent-AirlockMaint }
+    .suffix = Мим, Закрыт
+    .desc = { ent-AirlockMaint.desc }

--- a/Resources/Locale/ru-RU/ss220/prototypes/entities/structures/doors/airlocks/access.ftl
+++ b/Resources/Locale/ru-RU/ss220/prototypes/entities/structures/doors/airlocks/access.ftl
@@ -247,10 +247,10 @@ ent-AirlockClownLocked = { ent-AirlockClown }
     .desc = { ent-AirlockServiceGlassLocked.desc }
 
 ent-AirlockClownMaintLocked = { ent-AirlockMaint }
-    .suffix = Клоун, Закрыт
+    .suffix = { ent-AirlockClownLocked.suffix }
     .desc = { ent-AirlockMaint.desc }
 
 ent-AirlockMimeMaintLocked = { ent-AirlockMaint }
-    .suffix = Мим, Закрыт
+    .suffix = { ent-AirlockGlassMimeLocked.suffix }
     .desc = { ent-AirlockMaint.desc }
 

--- a/Resources/Locale/ru-RU/ss220/prototypes/entities/structures/doors/airlocks/access.ftl
+++ b/Resources/Locale/ru-RU/ss220/prototypes/entities/structures/doors/airlocks/access.ftl
@@ -253,3 +253,4 @@ ent-AirlockClownMaintLocked = { ent-AirlockMaint }
 ent-AirlockMimeMaintLocked = { ent-AirlockMaint }
     .suffix = Мим, Закрыт
     .desc = { ent-AirlockMaint.desc }
+

--- a/Resources/Prototypes/SS220/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/SS220/Entities/Structures/Doors/Airlocks/access.yml
@@ -108,6 +108,16 @@
     containers:
       board: [ DoorElectronicsMime ]
 
+# Musician
+- type: entity
+  parent: AirlockMaint
+  id: AirlockMusicianMaintLocked
+  suffix: Musician, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMusician ]
+
 # External access
 - type: entity
   parent: AirlockExternalGlass

--- a/Resources/Prototypes/SS220/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/SS220/Entities/Structures/Doors/Airlocks/access.yml
@@ -89,6 +89,25 @@
     containers:
       board: [ DoorElectronicsTheatre ]
 
+- type: entity
+  parent: AirlockMaint
+  id: AirlockClownMaintLocked
+  suffix: Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsClown ]
+
+# Mime
+- type: entity
+  parent: AirlockMaint
+  id: AirlockMimeMaintLocked
+  suffix: Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMime ]
+
 # External access
 - type: entity
   parent: AirlockExternalGlass

--- a/Resources/Prototypes/SS220/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/SS220/Entities/Structures/Doors/Airlocks/access.yml
@@ -92,7 +92,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockClownMaintLocked
-  suffix: Locked
+  suffix: Clown, Locked
   components:
   - type: ContainerFill
     containers:
@@ -102,7 +102,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMimeMaintLocked
-  suffix: Locked
+  suffix: Mime, Locked
   components:
   - type: ContainerFill
     containers:


### PR DESCRIPTION
## Описание PR
Запрос от мейнтейнера маппера.
Добавляет 3 шлюза "Техобслуживание" в спавн с доступами клоуна, мима и музыканта.
Внешний вид, описание и название как у обычной версии, отличие только в доступе и удобстве в маппинге.

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: retrocringe
- add: [Маппинг] Добавлены 3 шлюза техобслуживания с доступами клоуна, мима и музыканта в меню спавна.