### PR TITLE
FIX: Невозможно зомбифицировать трупы

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -275,11 +275,6 @@ namespace Content.Server.Zombies
                 }
                 else
                 {
-                    //SS220 no_heal_from_zombies start
-                    if (HasComp<ZombieComponent>(entity))
-                        continue;
-                    //SS220 no_heal_from_zombies end
-
                     if (HasComp<ZombieImmuneComponent>(uid) || cannotSpread)
                         continue;
 


### PR DESCRIPTION
## Описание PR

Исправляет #4430 — укус зомби больше не проходит "вхолостую" по трупам, тела снова обращаются.

**Причина**

Апстримный PR space-wizards#41007 (*Zombies can't hurt II*), приехавший к нам вместе с #4080, переписал `OnMeleeHit` и поменял смысл идентификаторов местами:

| | было | стало |
|---|---|---|
| `entity` | **цель** укуса (переменная цикла) | **атакующий зомби** (`Entity<ZombieComponent>`) |
| `uid` | атакующий зомби | **цель** укуса (переменная цикла) |

Наша старая правка `no_heal_from_zombies` (из #848) при мерже была перенесена дословно и попала в ветку для мёртвых/критовых целей:

```cs
else   // цель не жива
{
    //SS220 no_heal_from_zombies start
    if (HasComp<ZombieComponent>(entity))   // entity — это сам АТАКУЮЩИЙ зомби
        continue;                            // ← всегда true, всегда continue
    //SS220 no_heal_from_zombies end

    ZombifyEntity(uid);   // недостижимо
}
```

Тут `entity` это `Entity<ZombieComponent>` самой подписки, поэтому `HasComp<ZombieComponent>(entity)` всегда true. Каждый укус трупа уходил в `continue` до вызова `ZombifyEntity`.

**Решение**

Правка удалена целиком. Её изначальное назначение в том, чтобы не хилиться от укусов других зомби. Это уже полностью покрыто апстримной проверкой выше по циклу, которая пропускает любую цель с `ZombieComponent`/`IncurableZombieComponent` до обеих веток лечения:

```cs
if (HasComp<ZombieComponent>(uid) || HasComp<IncurableZombieComponent>(uid))
{
    // Don't infect, don't deal damage, do not heal from bites, don't pass go!
    args.Handled = true;
    continue;
}
```

**Медиа**
| Было | Стало|
| -------- | ------- |
| https://github.com/user-attachments/assets/f4867c0a-ac09-4bea-8dd4-0276596250cc | https://github.com/user-attachments/assets/13be7c93-e5a8-47e4-98de-53c21141b882 |







<!--CLIgnore-->
**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl:
- fix: Зомби снова могут обращать трупы укусом.