### PR TITLE
FIX: NDA accept workflow crashes on author check

### DIFF
--- a/.github/workflows/contributor-team-accept.yml
+++ b/.github/workflows/contributor-team-accept.yml
@@ -23,7 +23,8 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            if (context.payload.comment.user.login !== context.payload.pull_request.user.login) {
+            // issue_comment payload has no top-level `pull_request`; PR author is issue.user
+            if (context.payload.comment.user.login !== context.payload.issue.user.login) {
               return;
             }
             try {


### PR DESCRIPTION
<!-- Заголовок PR: FIX: Воркфлоу NDA accept падает на проверке автора -->

## Описание PR

Воркфлоу `contributor-team-accept.yml` падал с `TypeError: Cannot read properties of undefined (reading 'user')` на первой же строке скрипта. [Пример](https://github.com/SerbiaStrong-220/space-station-14/actions/runs/30221351174/job/89844236879)

Причина: у события `issue_comment` в payload нет ключа `pull_request`. Автор PR берётся из `context.payload.issue.user`. Вложенный `issue.pull_request` — это объект со ссылками (`url`, `html_url`, `diff_url`, `patch_url`, `merged_at`), поля `user` в нём нет.

Проверено локальным прогоном строки на реальном payload'е `issue_comment` из этого репозитория: старый вариант воспроизводит ту же ошибку, новый отрабатывает корректно.

Остальные воркфлоу проверены на такую же ошибку — `context.payload.pull_request` больше нигде не используется с несовместимым триггером.

**Медиа**
<!-- Не требуется, изменение только в CI. -->

<!--CLIgnore-->
**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
<!-- Изменение не влияет на игроков, список изменений не требуется. -->