### PR TITLE
FIX: Vending machine/bot speech flooding chat log

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.SS220.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.SS220.cs
@@ -8,10 +8,6 @@ namespace Content.Server.Chat.Systems;
 
 public sealed partial class ChatSystem
 {
-    /// <summary>
-    ///     Language aware version of <see cref="SendInVoiceRange"/>.
-    ///     Every listener receives its own variant of the message.
-    /// </summary>
     private void SendInVoiceRangeWithLanguage(
         LanguageMessage languageMessage,
         string name,
@@ -20,8 +16,6 @@ public sealed partial class ChatSystem
         EntityUid source,
         ChatTransmitRange range)
     {
-        var wrapId = speech.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message";
-
         foreach (var (session, data) in GetRecipients(source, VoiceRange))
         {
             var entRange = MessageRangeCheck(session, data, range);
@@ -33,13 +27,19 @@ public sealed partial class ChatSystem
 
             var scrambledMessage = languageMessage.GetMessage(listener, true);
             var entHideChat = entRange == MessageRangeCheckResult.HideChat;
-            _chatManager.ChatMessageToOne(ChatChannel.Local, scrambledMessage, Wrap(scrambledMessage), source, entHideChat, session.Channel);
+            var wrappedMessage = WrapSpokenMessage(scrambledMessage, name, verb, speech);
+            _chatManager.ChatMessageToOne(ChatChannel.Local, scrambledMessage, wrappedMessage, source, entHideChat, session.Channel);
         }
 
         var sourceMessage = languageMessage.GetMessage(source, false);
-        _replay.RecordServerMessage(new ChatMessage(ChatChannel.Local, sourceMessage, Wrap(sourceMessage), GetNetEntity(source), null, MessageRangeHideChatForReplay(range)));
+        var sourceWrappedMessage = WrapSpokenMessage(sourceMessage, name, verb, speech);
+        _replay.RecordServerMessage(new ChatMessage(ChatChannel.Local, sourceMessage, sourceWrappedMessage, GetNetEntity(source), null, MessageRangeHideChatForReplay(range)));
+    }
 
-        string Wrap(string message) => Loc.GetString(wrapId,
+    private string WrapSpokenMessage(string message, string name, string verb, SpeechVerbPrototype speech)
+    {
+        var wrapId = speech.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message";
+        return Loc.GetString(wrapId,
             ("entityName", name),
             ("verb", verb),
             ("fontType", speech.FontId),

--- a/Content.Server/Chat/Systems/ChatSystem.SS220.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.SS220.cs
@@ -1,0 +1,49 @@
+// © SS220, An EULA/CLA with a hosting restriction, full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/CLA.txt
+
+using Content.Shared.Chat;
+using Content.Shared.Speech;
+using Content.Shared.SS220.Language.Systems;
+
+namespace Content.Server.Chat.Systems;
+
+public sealed partial class ChatSystem
+{
+    /// <summary>
+    ///     Language aware version of <see cref="SendInVoiceRange"/>.
+    ///     Every listener receives its own variant of the message.
+    /// </summary>
+    private void SendInVoiceRangeWithLanguage(
+        LanguageMessage languageMessage,
+        string name,
+        string verb,
+        SpeechVerbPrototype speech,
+        EntityUid source,
+        ChatTransmitRange range)
+    {
+        var wrapId = speech.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message";
+
+        foreach (var (session, data) in GetRecipients(source, VoiceRange))
+        {
+            var entRange = MessageRangeCheck(session, data, range);
+            if (entRange == MessageRangeCheckResult.Disallowed)
+                continue;
+
+            if (session.AttachedEntity is not { Valid: true } listener)
+                continue;
+
+            var scrambledMessage = languageMessage.GetMessage(listener, true);
+            var entHideChat = entRange == MessageRangeCheckResult.HideChat;
+            _chatManager.ChatMessageToOne(ChatChannel.Local, scrambledMessage, Wrap(scrambledMessage), source, entHideChat, session.Channel);
+        }
+
+        var sourceMessage = languageMessage.GetMessage(source, false);
+        _replay.RecordServerMessage(new ChatMessage(ChatChannel.Local, sourceMessage, Wrap(sourceMessage), GetNetEntity(source), null, MessageRangeHideChatForReplay(range)));
+
+        string Wrap(string message) => Loc.GetString(wrapId,
+            ("entityName", name),
+            ("verb", verb),
+            ("fontType", speech.FontId),
+            ("fontSize", speech.FontSize),
+            ("message", message));
+    }
+}

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -518,6 +518,10 @@ public sealed partial class ChatSystem : SharedChatSystem
         var languageMessage = _languageSystem.SanitizeMessage(source, message);
         foreach (var (session, data) in GetRecipients(source, VoiceRange))
         {
+            var entRange = MessageRangeCheck(session, data, range);
+            if (entRange == MessageRangeCheckResult.Disallowed)
+                continue;
+
             if (session.AttachedEntity is not { Valid: true } playerEntity)
                 continue;
 
@@ -533,12 +537,20 @@ public sealed partial class ChatSystem : SharedChatSystem
                 ("message", scrambledMessage /*SS220-Add-Languages*/));
 
             //SS220-Add-Languages begin
-            _chatManager.ChatMessageToOne(ChatChannel.Local, scrambledMessage, wrappedMessage, source, false, session.Channel);
+            var entHideChat = entRange == MessageRangeCheckResult.HideChat;
+            _chatManager.ChatMessageToOne(ChatChannel.Local, scrambledMessage, wrappedMessage, source, entHideChat, session.Channel);
         }
         //SS220-Add-Languages begin
         message = languageMessage.GetMessage(source, false);
 
-        //SendInVoiceRange(ChatChannel.Local, message, wrappedMessage, source, range);
+        var sourceWrappedMessage = Loc.GetString(speech.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message",
+            ("entityName", name),
+            ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
+            ("fontType", speech.FontId),
+            ("fontSize", speech.FontSize),
+            ("message", message));
+
+        _replay.RecordServerMessage(new ChatMessage(ChatChannel.Local, message, sourceWrappedMessage, GetNetEntity(source), null, MessageRangeHideChatForReplay(range)));
         var ev = new EntitySpokeEvent(source, message, originalMessage, null, null, languageMessage);
         RaiseLocalEvent(source, ev, true);
         //SS220-Add-Languages end

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -516,41 +516,12 @@ public sealed partial class ChatSystem : SharedChatSystem
         name = FormattedMessage.EscapeText(name);
         // SS220-Add-Languages begin
         var languageMessage = _languageSystem.SanitizeMessage(source, message);
-        foreach (var (session, data) in GetRecipients(source, VoiceRange))
-        {
-            var entRange = MessageRangeCheck(session, data, range);
-            if (entRange == MessageRangeCheckResult.Disallowed)
-                continue;
+        var verb = Loc.GetString(_random.Pick(speech.SpeechVerbStrings));
 
-            if (session.AttachedEntity is not { Valid: true } playerEntity)
-                continue;
+        //SendInVoiceRange(ChatChannel.Local, message, wrappedMessage, source, range);
+        SendInVoiceRangeWithLanguage(languageMessage, name, verb, speech, source, range);
 
-            var listener = session.AttachedEntity.Value;
-            var scrambledMessage = languageMessage.GetMessage(listener, true);
-        // SS220-Add-Languages end
-
-            var wrappedMessage = Loc.GetString(speech.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message",
-                ("entityName", name),
-                ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
-                ("fontType", speech.FontId),
-                ("fontSize", speech.FontSize),
-                ("message", scrambledMessage /*SS220-Add-Languages*/));
-
-            //SS220-Add-Languages begin
-            var entHideChat = entRange == MessageRangeCheckResult.HideChat;
-            _chatManager.ChatMessageToOne(ChatChannel.Local, scrambledMessage, wrappedMessage, source, entHideChat, session.Channel);
-        }
-        //SS220-Add-Languages begin
         message = languageMessage.GetMessage(source, false);
-
-        var sourceWrappedMessage = Loc.GetString(speech.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message",
-            ("entityName", name),
-            ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
-            ("fontType", speech.FontId),
-            ("fontSize", speech.FontSize),
-            ("message", message));
-
-        _replay.RecordServerMessage(new ChatMessage(ChatChannel.Local, message, sourceWrappedMessage, GetNetEntity(source), null, MessageRangeHideChatForReplay(range)));
         var ev = new EntitySpokeEvent(source, message, originalMessage, null, null, languageMessage);
         RaiseLocalEvent(source, ev, true);
         //SS220-Add-Languages end


### PR DESCRIPTION
## Описание PR

Реплики торговых автоматов (вендинги) и ботов (MedBot и т.п.) дублировались в чат-лог на каждую строчку, вместо того чтобы оставаться только речевым пузырём + TTS. При нескольких закреплённых медиботах чат забивается флудом за пару минут, что мешает искать нужные сообщения.

**Причина.** SS220-патч с языковой рандомизацией (`SS220-Add-Languages`) переписал `ChatSystem.SendEntitySpeak` (`Content.Server/Chat/Systems/ChatSystem.cs`) на цикл по каждому получателю (чтобы у каждого слушателя была своя "перемешанная" по языку версия сообщения). При этом переписывании:
- Аргумент `hideChat` в вызове `ChatMessageToOne` был захардкожен в `false`;
- `MessageRangeCheck` вообще перестал вызываться, хотя параметр `range` (`ChatTransmitRange`) как принимался в функцию, так и остался неиспользуемым;
- Старый вызов `SendInVoiceRange(...)`, который раньше всё это корректно обрабатывал, остался закомментированным мёртвым кодом.

Сущности вроде медиботов и вендингов выставляют `VocalizerComponent.HideChat = true`, что должно транслироваться в `ChatTransmitRange.HideChat` — только пузырь и TTS, без записи в чат-лог. Из-за пропавшей проверки диапазона любое "say"-сообщение стало принудительно попадать в чат-лог независимо от этого флага.

**Исправление.**
- Добавлен и использован альтернативный метод `SendInVoiceRangeWithLanguage`. 

Fixes: https://github.com/SerbiaStrong-220/space-station-14/issues/4328

**Медиа**
<!--CLIgnore-->
<s>Не визуальное изменение — влияет только на то, попадает ли реплика в чат-лог. Скриншот не требуется.</s>
Я передумал. До/После

| До | После |
| -------- | ------- |
| <img width="720" height="405" alt="medibots_before" src="https://github.com/user-attachments/assets/b006a939-f790-44aa-97bf-b248b28518a5" /> | <img width="720" height="476" alt="medibots_after" src="https://github.com/user-attachments/assets/5551ccc8-df96-4eaf-8af9-a5baebc53cda" />  |
<!--/CLIgnore-->

<!--CLIgnore-->
**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl:
- fix: Исправлен флуд в чате от реплик торговых автоматов и ботов — теперь они снова отображаются только речевым пузырём и TTS, без дублирования в чат-лог.
