### PR TITLE
FIX: Sponsor/premium loadout items stripped after server restart

### DIFF
--- a/Content.Server/SS220/Discord/DiscordPlayerManager.cs
+++ b/Content.Server/SS220/Discord/DiscordPlayerManager.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Content.Server.Administration.Managers;
+using Content.Server.Database;
 using Content.Shared.CCVar;
 using Content.Shared.Players;
 using Content.Shared.SS220.CCVars;
@@ -29,6 +30,7 @@ public sealed partial class DiscordPlayerManager : IPostInjectInit, IDisposable
     [Dependency] private IServerNetManager _netMgr = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
     [Dependency] private IAdminManager _adminManager = default!;
+    [Dependency] private UserDbDataManager _userDb = default!;
 
     internal SponsorUsers? CachedSponsorUsers => _cachedSponsorUsers;
 
@@ -43,6 +45,7 @@ public sealed partial class DiscordPlayerManager : IPostInjectInit, IDisposable
     public event EventHandler<ICommonSession>? PlayerVerified;
 
     private volatile Dictionary<NetUserId, DiscordSponsorInfo?> _cachedSponsorInfo = new();
+    private volatile Dictionary<NetUserId, bool> _sponsorInfoFetchFailed = new();
 
     public List<SponsorTier> PriorityJoinTiers =
     [
@@ -78,6 +81,47 @@ public sealed partial class DiscordPlayerManager : IPostInjectInit, IDisposable
             dueTime: TimeSpan.FromSeconds(_cfg.GetCVar(CCVars220.DiscordSponsorsCacheLoadDelaySeconds)),
             period: TimeSpan.FromSeconds(_cfg.GetCVar(CCVars220.DiscordSponsorsCacheRefreshIntervalSeconds))
         );
+
+        // Fetch sponsor info as part of the user-db *load* step (the tasks that UserDbDataManager
+        // awaits via Task.WhenAll before running any "on finish load" callback, including
+        // ServerPreferencesManager.FinishLoad -> SanitizePreferences -> loadout validation).
+        // This guarantees ContentPlayerData.SponsorInfo is populated (or definitively marked as
+        // failed) before sponsor-gated loadout items are validated and before the player can spawn.
+        // Previously this ran off an independent PlayerStatusChanged subscription racing against
+        // GameTicker's own preferences load, which could strip sponsor loadout items if the HTTP
+        // fetch hadn't completed yet (especially right after a server restart with a cold connection).
+        _userDb.AddOnLoadPlayer(OnLoadPlayer);
+    }
+
+    private async Task OnLoadPlayer(ICommonSession session, CancellationToken cancel)
+    {
+        if (!_isDiscordLinkRequired && string.IsNullOrEmpty(_linkApiUrl))
+            return;
+
+        await UpdateSponsorInfo(session.UserId);
+        ApplySponsorInfo(session);
+    }
+
+    private void ApplySponsorInfo(ICommonSession session)
+    {
+        _cachedSponsorInfo.TryGetValue(session.UserId, out var info);
+        _sponsorInfoFetchFailed.TryGetValue(session.UserId, out var fetchFailed);
+
+        var contentPlayerData = session.ContentData();
+        if (contentPlayerData == null)
+            return;
+
+        contentPlayerData.SponsorInfo = info;
+        contentPlayerData.SponsorInfoFetchFailed = fetchFailed;
+
+        if (info is not null)
+        {
+            _netMgr.ServerSendMessage(new MsgUpdatePlayerDiscordStatus
+            {
+                Info = info
+            },
+            session.Channel);
+        }
     }
 
     private void ByPassDiscordCheck(MsgByPassDiscordCheck msg)
@@ -135,44 +179,24 @@ public sealed partial class DiscordPlayerManager : IPostInjectInit, IDisposable
             e.Session.Channel.SendMessage(msg);
         }
 
-        if (e.NewStatus == SessionStatus.InGame)
-        {
-            await UpdateUserDiscordRolesStatus(e);
-        }
-
         if (e.NewStatus == SessionStatus.Disconnected)
         {
             _cachedSponsorInfo.Remove(e.Session.UserId);
+            _sponsorInfoFetchFailed.Remove(e.Session.UserId);
         }
     }
 
-    private async Task UpdateUserDiscordRolesStatus(SessionStatusEventArgs e)
-    {
-        await UpdateSponsorInfo(e.Session.UserId);
-        _cachedSponsorInfo.TryGetValue(e.Session.UserId, out var info);
-
-        if (info is not null)
-        {
-            _netMgr.ServerSendMessage(new MsgUpdatePlayerDiscordStatus
-            {
-                Info = info
-            },
-            e.Session.Channel);
-
-            // Cache info in content data
-            var contentPlayerData = e.Session.ContentData();
-            if (contentPlayerData == null)
-                return;
-
-            contentPlayerData.SponsorInfo = info;
-        }
-    }
-
-    private async Task<DiscordSponsorInfo?> GetSponsorInfo(NetUserId userId)
+    /// <returns>
+    /// The fetched sponsor info (null if the player has no sponsor tiers), and whether the fetch
+    /// itself succeeded. A null result with <c>Success: true</c> means "we asked and the player has
+    /// no tiers"; <c>Success: false</c> means the premium-checker service was unavailable/errored and
+    /// we don't actually know the player's status.
+    /// </returns>
+    private async Task<(DiscordSponsorInfo? Info, bool Success)> GetSponsorInfo(NetUserId userId)
     {
         if (string.IsNullOrEmpty(_linkApiUrl))
         {
-            return null;
+            return (null, true);
         }
 
         try
@@ -189,17 +213,18 @@ public sealed partial class DiscordPlayerManager : IPostInjectInit, IDisposable
                     response.StatusCode,
                     errorText);
 
-                return null;
+                return (null, false);
             }
 
-            return await response.Content.ReadFromJsonAsync<DiscordSponsorInfo>(GetJsonSerializerOptions());
+            var info = await response.Content.ReadFromJsonAsync<DiscordSponsorInfo>(GetJsonSerializerOptions());
+            return (info, true);
         }
         catch (Exception exc)
         {
             _sawmill.Error(exc.Message);
         }
 
-        return null;
+        return (null, false);
     }
 
     public async Task<string> GetUserLink(NetUserId userId)
@@ -348,14 +373,16 @@ public sealed partial class DiscordPlayerManager : IPostInjectInit, IDisposable
 
     public async Task UpdateSponsorInfo(NetUserId userId)
     {
-        var sponsorInfo = await GetSponsorInfo(userId);
+        var (sponsorInfo, success) = await GetSponsorInfo(userId);
         _cachedSponsorInfo[userId] = sponsorInfo;
+        _sponsorInfoFetchFailed[userId] = !success;
     }
 
     public async Task<bool> HasPriorityJoinTierAsync(NetUserId userId)
     {
         await UpdateSponsorInfo(userId);
-        return HasPriorityJoinTier(await GetSponsorInfo(userId));
+        _cachedSponsorInfo.TryGetValue(userId, out var info);
+        return HasPriorityJoinTier(info);
     }
 
     public bool HasPriorityJoinTier(NetUserId userId)

--- a/Content.Server/SS220/Discord/DiscordPlayerManager.cs
+++ b/Content.Server/SS220/Discord/DiscordPlayerManager.cs
@@ -82,14 +82,7 @@ public sealed partial class DiscordPlayerManager : IPostInjectInit, IDisposable
             period: TimeSpan.FromSeconds(_cfg.GetCVar(CCVars220.DiscordSponsorsCacheRefreshIntervalSeconds))
         );
 
-        // Fetch sponsor info as part of the user-db *load* step (the tasks that UserDbDataManager
-        // awaits via Task.WhenAll before running any "on finish load" callback, including
-        // ServerPreferencesManager.FinishLoad -> SanitizePreferences -> loadout validation).
-        // This guarantees ContentPlayerData.SponsorInfo is populated (or definitively marked as
-        // failed) before sponsor-gated loadout items are validated and before the player can spawn.
-        // Previously this ran off an independent PlayerStatusChanged subscription racing against
-        // GameTicker's own preferences load, which could strip sponsor loadout items if the HTTP
-        // fetch hadn't completed yet (especially right after a server restart with a cold connection).
+        // Runs as a load hook so the fetch is awaited before preferences are sanitized and validated.
         _userDb.AddOnLoadPlayer(OnLoadPlayer);
     }
 
@@ -186,12 +179,7 @@ public sealed partial class DiscordPlayerManager : IPostInjectInit, IDisposable
         }
     }
 
-    /// <returns>
-    /// The fetched sponsor info (null if the player has no sponsor tiers), and whether the fetch
-    /// itself succeeded. A null result with <c>Success: true</c> means "we asked and the player has
-    /// no tiers"; <c>Success: false</c> means the premium-checker service was unavailable/errored and
-    /// we don't actually know the player's status.
-    /// </returns>
+    /// <returns><c>Success: false</c> means the service could not be reached, not that the player has no tiers.</returns>
     private async Task<(DiscordSponsorInfo? Info, bool Success)> GetSponsorInfo(NetUserId userId)
     {
         if (string.IsNullOrEmpty(_linkApiUrl))

--- a/Content.Server/SS220/Loadouts/SponsorTierRequirementLoadoutEffect.cs
+++ b/Content.Server/SS220/Loadouts/SponsorTierRequirementLoadoutEffect.cs
@@ -23,9 +23,7 @@ public sealed partial class SponsorTierRequirementLoadoutEffect : SharedSponsorT
             return false;
         }
 
-        // The premium-checker service was unavailable/errored when we tried to fetch this player's
-        // sponsor status, so we can't tell "not a sponsor" from "couldn't ask". Fail open rather than
-        // silently stripping an already-selected sponsor item on every restart/reconnect.
+        // Fail open: the fetch failed, so "not a sponsor" is indistinguishable from "could not ask".
         if (contentData.SponsorInfoFetchFailed)
             return true;
 

--- a/Content.Server/SS220/Loadouts/SponsorTierRequirementLoadoutEffect.cs
+++ b/Content.Server/SS220/Loadouts/SponsorTierRequirementLoadoutEffect.cs
@@ -16,7 +16,20 @@ public sealed partial class SponsorTierRequirementLoadoutEffect : SharedSponsorT
     public override bool Validate(HumanoidCharacterProfile profile, RoleLoadout loadout, ICommonSession? session, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason)
     {
         reason = new FormattedMessage();
-        if (session == null || session.ContentData()?.SponsorInfo?.Tiers is not { } playerTiers)
+        var contentData = session?.ContentData();
+        if (contentData == null)
+        {
+            reason = FormattedMessage.Empty;
+            return false;
+        }
+
+        // The premium-checker service was unavailable/errored when we tried to fetch this player's
+        // sponsor status, so we can't tell "not a sponsor" from "couldn't ask". Fail open rather than
+        // silently stripping an already-selected sponsor item on every restart/reconnect.
+        if (contentData.SponsorInfoFetchFailed)
+            return true;
+
+        if (contentData.SponsorInfo?.Tiers is not { } playerTiers)
         {
             reason = FormattedMessage.Empty;
             return false;

--- a/Content.Shared/Players/ContentPlayerData.cs
+++ b/Content.Shared/Players/ContentPlayerData.cs
@@ -39,6 +39,15 @@ public sealed class ContentPlayerData
 
     [ViewVariables(VVAccess.ReadOnly)]
     public DiscordSponsorInfo? SponsorInfo = null;
+
+    /// <summary>
+    /// True if the last attempt to fetch <see cref="SponsorInfo"/> from the premium-checker service
+    /// failed or timed out (as opposed to succeeding with no sponsor tiers). Loadout validation should
+    /// fail open (not strip sponsor items) in this case, since we can't distinguish "not a sponsor"
+    /// from "couldn't ask".
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public bool SponsorInfoFetchFailed = false;
     //SS220 Shlepovend end
 
     /// <summary>

--- a/Content.Shared/Players/ContentPlayerData.cs
+++ b/Content.Shared/Players/ContentPlayerData.cs
@@ -40,12 +40,7 @@ public sealed class ContentPlayerData
     [ViewVariables(VVAccess.ReadOnly)]
     public DiscordSponsorInfo? SponsorInfo = null;
 
-    /// <summary>
-    /// True if the last attempt to fetch <see cref="SponsorInfo"/> from the premium-checker service
-    /// failed or timed out (as opposed to succeeding with no sponsor tiers). Loadout validation should
-    /// fail open (not strip sponsor items) in this case, since we can't distinguish "not a sponsor"
-    /// from "couldn't ask".
-    /// </summary>
+    /// <summary>Set when the fetch failed, as opposed to succeeding with no tiers.</summary>
     [ViewVariables(VVAccess.ReadOnly)]
     public bool SponsorInfoFetchFailed = false;
     //SS220 Shlepovend end


### PR DESCRIPTION
## Описание PR

После рестарта сервера у игроков слетали выбранные в лоадауте спонсорские предметы (и похожие "премиум" предметы, например, сеньёрские вещи капитана). Причина — гонка (race condition) между двумя независимыми асинхронными операциями, происходящими при подключении/переподключении игрока:

1. Загрузка профиля/предпочтений игрока из локальной БД (быстро — локальный SQLite);
2. Запрос статуса спонсора у внешнего "premium-checker" (Discord link API) — медленнее, реальный сетевой запрос.

`DiscordPlayerManager` запускал запрос спонсорского статуса через отдельный, независимый обработчик `PlayerStatusChanged`, никак не связанный с пайплайном загрузки предпочтений игрока (`UserDbDataManager` / `ServerPreferencesManager`). Из-за этого валидация лоадаута (`SponsorTierRequirementLoadoutEffect.Validate`) почти всегда успевала отработать раньше, чем приходил ответ от premium-checker: `ContentPlayerData.SponsorInfo` оставалась `null`, и валидатор считал это признаком отсутствия подписки, тихо вырезая уже выбранный спонсорский предмет из лоадаута. Особенно ярко это проявлялось сразу после рестарта сервера (холодное HTTP-соединение), но фактически могло случиться при любом подключении — вплоть до немедленного слёта предмета прямо в редакторе персонажа при быстром взаимодействии.

Отдельная проблема: если premium-checker был недоступен (таймаут, ошибка), это тоже трактовалось как "не спонсор" — то есть падение стороннего сервиса приводило к массовому и необратимому исчезновению уже выбранных спонсорских предметов у игроков (само исчезновение сохранялось в БД при следующем сохранении профиля).

**Исправление.**
- Запрос спонсорского статуса теперь регистрируется как часть пайплайна загрузки данных игрока (`UserDbDataManager.AddOnLoadPlayer`), который валидация профиля (`SanitizePreferences`/`RoleLoadout.EnsureValid`) и спавн игрока гарантированно дожидаются перед выполнением. Гонка устранена — порядок операций больше не зависит от того, какая из них "успеет" первой.
- Добавлен `ContentPlayerData.SponsorInfoFetchFailed`: если запрос к premium-checker завершился ошибкой/таймаутом, валидация лоадаута теперь **не отбирает** уже выбранные спонсорские предметы (fail-open), вместо того чтобы трактовать недоступность сервиса как "у игрока нет подписки" (fail-closed).

Изменения затрагивают `DiscordPlayerManager`, `SponsorTierRequirementLoadoutEffect` (server) и `ContentPlayerData`. Обычная (не спонсорская) логика лоадаутов не затронута.

Воспроизведено и проверено локально: поднят мок-сервер premium-checker API с управляемой задержкой ответа, сервер собран и перезапущен на коммите до фикса — спонсорский предмет пропадал после рестарта; на коммите с фиксом — предмет остаётся выбранным независимо от задержки ответа мок-сервера.

Fixes: SerbiaStrong-220/space-station-14#4428

**Медиа**
<!--CLIgnore-->
Не визуальное изменение — влияет на серверную логику валидации лоадаута. Скриншот/видео не требуется.
<!--/CLIgnore-->

<!--CLIgnore-->
**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl:
- fix: Исправлено исчезновение спонсорских/премиум предметов из лоадаута после рестарта сервера или при быстром взаимодействии с редактором персонажа.
- fix: Недоступность сервиса проверки спонсорского статуса больше не приводит к потере уже выбранных спонсорских предметов.
