### PR TITLE
Исправлен баг рендера при выбрасывании сингулярности под себя

### DIFF
--- a/Content.Client/Singularity/SingularityOverlay.cs
+++ b/Content.Client/Singularity/SingularityOverlay.cs
@@ -23,6 +23,7 @@ namespace Content.Client.Singularity
         ///     If this value is changed, the shader itself also needs to be updated.
         /// </summary>
         public const int MaxCount = 5;
+        private readonly Vector2 _safeDeltaValue = new(.1f, .1f);
 
         private const float MaxDistance = 20f;
 
@@ -130,7 +131,7 @@ namespace Content.Client.Singularity
 
                 var localPosition = _positions[i];
                 localPosition.Y = args.Viewport.Size.Y - localPosition.Y;
-                var delta = args.VisiblePosition - localPosition;
+                var delta = Vector2.Max(args.VisiblePosition - localPosition, _safeDeltaValue);
                 var distance = (delta / (args.Viewport.RenderScale * args.Viewport.Eye.Scale)).Length();
 
                 var deformation = _intensities[i] / MathF.Pow(distance, _falloffPowers[i]);

--- a/Content.Client/Singularity/SingularityOverlay.cs
+++ b/Content.Client/Singularity/SingularityOverlay.cs
@@ -23,7 +23,7 @@ namespace Content.Client.Singularity
         ///     If this value is changed, the shader itself also needs to be updated.
         /// </summary>
         public const int MaxCount = 5;
-        private readonly Vector2 _safeDeltaValue = new(.1f, .1f);
+        private readonly Vector2 _safeDeltaValue = new(.1f, .1f); // SS220 fixsingularitydrop
 
         private const float MaxDistance = 20f;
 
@@ -131,7 +131,7 @@ namespace Content.Client.Singularity
 
                 var localPosition = _positions[i];
                 localPosition.Y = args.Viewport.Size.Y - localPosition.Y;
-                var delta = Vector2.Max(args.VisiblePosition - localPosition, _safeDeltaValue);
+                var delta = Vector2.Max(args.VisiblePosition - localPosition, _safeDeltaValue); // SS220 fixsingularitydrop
                 var distance = (delta / (args.Viewport.RenderScale * args.Viewport.Eye.Scale)).Length();
 
                 var deformation = _intensities[i] / MathF.Pow(distance, _falloffPowers[i]);


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->
Был бог, баг поправлен

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру и опубликован на Discord-сервере после принятия вашего PR.

В список изменений следует помещать только то, что действительно важно игрокам.

В списке изменений обязательно должен присутствовать символ :cl:, чтобы бот распознал изменения.

Вы можете указать своё имя после символа :cl:, именно оно будет отображаться в игровом списке изменений (если имя не указано, бот возьмёт ваш логин на GitHub).  
Например: :cl: Ian

В списке изменений тип значка не является частью предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров
-->
no cl
