### PR TITLE
add flags for doafter modification

### DIFF
--- a/Content.Shared/DoAfter/DoAfterArgs.SS220.cs
+++ b/Content.Shared/DoAfter/DoAfterArgs.SS220.cs
@@ -1,0 +1,15 @@
+namespace Content.Shared.DoAfter;
+
+public sealed partial class DoAfterArgs
+{
+    public DoAfterArgFlags ArgFlags = DoAfterArgFlags.None;
+}
+
+[Flags]
+public enum DoAfterArgFlags : byte
+{
+    None = 0,
+
+    IgnoreTraitsModification = 1 << 1,
+    IgnoreExperienceModification = 1 << 2
+}

--- a/Content.Shared/SS220/ChangeSpeedDoAfters/ChangeSpeedDoAftersSystem.cs
+++ b/Content.Shared/SS220/ChangeSpeedDoAfters/ChangeSpeedDoAftersSystem.cs
@@ -21,6 +21,9 @@ public sealed partial class ChangeSpeedDoAftersSystem : EntitySystem
 
     private void OnDoAfterProccess(Entity<ChangeSpeedDoAftersComponent> ent, ref BeforeDoAfterStartEvent args)
     {
+        if (args.Args.ArgFlags.HasFlag(DoAfterArgFlags.IgnoreTraitsModification))
+            return;
+
         args.Args.DelayModifier *= ent.Comp.Coefficient;
 
         if (ent.Comp.ChanceToFail == null)

--- a/Content.Shared/SS220/Experience/Skill/DoAfterEffect/BaseDoAfterSkillSystem.cs
+++ b/Content.Shared/SS220/Experience/Skill/DoAfterEffect/BaseDoAfterSkillSystem.cs
@@ -70,6 +70,9 @@ public abstract partial class BaseDoAfterSkillSystem<TComp, TEvent> : SkillEntit
 
     protected virtual void OnDoAfterStart(Entity<TComp> entity, ref BeforeDoAfterStartEvent args)
     {
+        if (args.Args.ArgFlags.HasFlag(DoAfterArgFlags.IgnoreExperienceModification))
+            return;
+
         if (!entity.Comp.FullBlock)
         {
             args.Args.DelayModifier *= entity.Comp.DurationScale;
@@ -96,6 +99,9 @@ public abstract partial class BaseDoAfterSkillSystem<TComp, TEvent> : SkillEntit
 
     protected virtual void OnDoAfterEnd(Entity<TComp> entity, ref BeforeDoAfterCompleteEvent args)
     {
+        if (args.Args.ArgFlags.HasFlag(DoAfterArgFlags.IgnoreExperienceModification))
+            return;
+
         if (!GetPredictedRandomOnCurTick(GetNetEntity(entity), GetNetEntity(args.Args.User)).Prob(entity.Comp.FailureChance))
             return;
 

--- a/Content.Shared/SS220/Grab/SharedGrabSystem.cs
+++ b/Content.Shared/SS220/Grab/SharedGrabSystem.cs
@@ -19,9 +19,11 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
+using Content.Shared.Random.Helpers;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
+using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Physics.Components;
@@ -59,6 +61,12 @@ public abstract partial class SharedGrabSystem : EntitySystem
     private EntityQuery<GrabberComponent> _grabberQuery;
     private EntityQuery<PhysicsComponent> _physicsQuery;
 
+    // NOTE(Alvyr):
+    // for now const if it will be good -> make skill dependent
+    private const float PassiveGrabAttackMissChance = 0.5f;
+
+    private static readonly LocId PassiveGrabMissPopup = "entity-missed-in-passive-grab";
+
     public override void Initialize()
     {
         base.Initialize();
@@ -77,6 +85,7 @@ public abstract partial class SharedGrabSystem : EntitySystem
         SubscribeLocalEvent<GrabbableComponent, InteractionAttemptEvent>(OnInteractionAttempt);
         SubscribeLocalEvent<GrabbableComponent, DownAttemptEvent>(OnDownAttempt);
         SubscribeLocalEvent<GrabbableComponent, AttackAttemptEvent>(OnCanAttack);
+        SubscribeLocalEvent<GrabbableComponent, AttemptMeleeUserEvent>(OnAttemptMeleeUserEvent);
 
         SubscribeLocalEvent<GrabberComponent, AttemptMobTargetCollideEvent>(OnAttemptMobTargetCollide);
         SubscribeLocalEvent<GrabbableComponent, AttemptMobTargetCollideEvent>(OnAttemptMobTargetCollide);
@@ -179,8 +188,20 @@ public abstract partial class SharedGrabSystem : EntitySystem
 
     private void OnCanAttack(Entity<GrabbableComponent> grabbable, ref AttackAttemptEvent ev)
     {
-        if (IsGrabbed((grabbable, grabbable.Comp)))
+        if (grabbable.Comp.GrabStage > GrabStage.Passive)
             ev.Cancel();
+    }
+
+    private void OnAttemptMeleeUserEvent(Entity<GrabbableComponent> grabbable, ref AttemptMeleeUserEvent ev)
+    {
+        if (ev.Cancelled || grabbable.Comp.GrabStage != GrabStage.Passive)
+            return;
+
+        if (!SharedRandomExtensions.PredictedProb(_timing, PassiveGrabAttackMissChance, GetNetEntity(grabbable), GetNetEntity(ev.Weapon)))
+            return;
+
+        ev.Message = Loc.GetString(PassiveGrabMissPopup);
+        ev.Cancelled = true;
     }
 
     // cuz of mob collisions
@@ -318,7 +339,8 @@ public abstract partial class SharedGrabSystem : EntitySystem
             BlockDuplicate = true,
             BreakOnDamage = true,
             BreakOnMove = true,
-            DistanceThreshold = 2f
+            DistanceThreshold = 2f,
+            ArgFlags = DoAfterArgFlags.IgnoreTraitsModification | DoAfterArgFlags.IgnoreExperienceModification,
         };
 
         return _doAfter.TryStartDoAfter(args);

--- a/Resources/Locale/ru-RU/ss220/grab/component.ftl
+++ b/Resources/Locale/ru-RU/ss220/grab/component.ftl
@@ -3,3 +3,4 @@ grabber-component-new-grab-popup = { $grabber } берёт { $grabbable } в з�
 grabber-component-grab-upgrade-popup = { $grabber } усиливает захват над { $grabbable }!
 grabbable-component-break-free = { $grabbable } вырвался из захвата!
 grab-resistance-component-resisting = { $grabbable } сопротивляется захвату!
+entity-missed-in-passive-grab = Вас держат не так крепко, ещё есть шанс!


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->

Игроки давно просили, да и на самом деле это нужна штука в диком западе ивентов.
Пока под руку попался ещё граб решил дать возможность с каким-то шансом ударить обидчика, но пока не тестил, так что драфт.

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру и опубликован на Discord-сервере после принятия вашего PR.

В список изменений следует помещать только то, что действительно важно игрокам.

В списке изменений обязательно должен присутствовать символ :cl:, чтобы бот распознал изменения.

Вы можете указать своё имя после символа :cl:, именно оно будет отображаться в игровом списке изменений (если имя не указано, бот возьмёт ваш логин на GitHub).  
Например: :cl: Ian

В списке изменений тип значка не является частью предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров
-->


:cl: AlwyAnri
- add: Добавлен шанс успешно ударить будучи в пассивном захвате
- tweak: Влияние модификаторов на скорость взятия в захват убрана (речь про трейты). Возвращение будет когда появится более продвинутая градация по этим параметрам.
