### PR TITLE
[ADD/FIX] Соус "Дыхание Ётуна" и фикс соуса "Тёмный жнец"

### DIFF
--- a/Resources/Locale/ru-RU/ss220/reagents/meta/drinks.ftl
+++ b/Resources/Locale/ru-RU/ss220/reagents/meta/drinks.ftl
@@ -28,3 +28,6 @@ reagent-name-skooma = скума
 reagent-desc-skooma = Не давать таяранам. Не говорить о ней таяранам.
 reagent-name-catariajuice = мятный сок
 reagent-desc-catariajuice = Притягивает кошек.
+reagent-name-YotunBreath = соус "Дыхание Ётуна"
+reagent-desc-YotunBreath = Этот соус пропитан дыханием вечного холода. Он способен проморозить вас до костей.
+yotun-breath-effect-freeze = Вас пробирает ледяной озноб, вы ощущаете дыхание Ётуна!

--- a/Resources/Prototypes/SS220/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/SS220/Reagents/Consumable/Drink/drinks.yml
@@ -122,8 +122,6 @@
       - !type:AdjustReagent
         reagent: Nutriment
         amount: 2.0
-    Bloodstream:
-      effects:
       - !type:HealthChange
         damage:
           types:
@@ -142,6 +140,39 @@
         visualType: MediumCaution
         type: Local
         messages: [ "capsaicin-effect-heavy-burn" ]
+        probability: 0.4
+
+#YotunBreath
+- type: reagent
+  id: YotunBreath
+  name: reagent-name-YotunBreath
+  parent: BaseDrink
+  desc: reagent-desc-YotunBreath
+  physicalDesc: reagent-physical-desc-frosty
+  flavor: cold
+  color: "#5ac6e7"
+  recognizable: true
+  metabolisms:
+    Digestion:
+      effects:
+      - !type:SatiateThirst
+        factor: 0.5
+      - !type:AdjustReagent
+        reagent: Nutriment
+        amount: 2.0
+      - !type:HealthChange
+        damage:
+          types:
+            Cold: -1
+      - !type:AdjustTemperature
+        conditions:
+        - !type:TemperatureCondition
+          min: 220.0
+        amount: -100000
+      - !type:PopupMessage
+        visualType: MediumCaution
+        type: Local
+        messages: [ "yotun-breath-effect-freeze" ]
         probability: 0.4
 
 #RrrantaFeature

--- a/Resources/Prototypes/SS220/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/SS220/Recipes/Reactions/drinks.yml
@@ -89,6 +89,18 @@
     ReaperSauce: 4
 
 - type: reaction
+  id: YotunBreath
+  reactants:
+    FrostOil:
+      amount: 2
+    Nitrogen:
+      amount: 1
+    Ice:
+      amount: 1
+  products:
+    YotunBreath: 4
+
+- type: reaction
   id: Bacchus
   requiredMixerCategories:
   - Shake


### PR DESCRIPTION
## Описание PR
close: https://github.com/SerbiaStrong-220/DevTeam220/issues/423
Добавляет противоположный жгучему соусу "Тёмный жнец" - холодный соус "Дыхание Ётуна"

Эффекты:
Убирает 100,0 кДж тепла к телу, в котором он метаболизируется , пока температура тела составляет не менее 220,00k.
Излечивает 1 ед. обморожение, утоляет голод 2 ед, утоляет жажду.

Рецепт:
2 Frost oil (добывается из чилли)
1 Азот
1 Лёд
Получаем: 4 Соус "Дыхание Ётуна"

Фикс:
Во время создания нового соуса заметил что основной эффект соуса в понижении температуры не работает. Проверив работает ли другой соус убедился что проблема и с ним тоже, так как создавал на основе его. За эффекты через метаболизм отвечает Digestion, бладстрим тут не нужен.

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: retrocringe
- add: Добавлен новый соус "Дыхание Ётуна", антипод соусу "Тёмный жнец"
- fix: Соус "Тёмный жнец" теперь снова работает.