### PR TITLE
[FIX] IntimidateObjective

### DIFF
--- a/Content.Server/SS220/Objectives/Components/IntimidatePersonConditionComponent.cs
+++ b/Content.Server/SS220/Objectives/Components/IntimidatePersonConditionComponent.cs
@@ -36,7 +36,7 @@ public sealed partial class IntimidatePersonConditionComponent : Component
     /// Description will be applied if target gets SSDs.
     /// </summary>
     [DataField(required: true)]
-    public string? CatatonicDescription; // SS220 rewrite: brings from handle ssd state to catatonic
+    public string? CatatonicDescription;
 
     [DataField]
     public MindPool Pool = new AliveHumansPool();

--- a/Content.Server/SS220/Objectives/Components/IntimidatePersonConditionComponent.cs
+++ b/Content.Server/SS220/Objectives/Components/IntimidatePersonConditionComponent.cs
@@ -52,5 +52,5 @@ public enum IntimidatePersonDescriptionType
 {
     Start = 0,
     Success,
-    Catatoinic, // SS220 rewrite: brings from handle ssd state to catatonic
+    Catatoinic,
 }

--- a/Content.Server/SS220/Objectives/Components/IntimidatePersonConditionComponent.cs
+++ b/Content.Server/SS220/Objectives/Components/IntimidatePersonConditionComponent.cs
@@ -36,7 +36,7 @@ public sealed partial class IntimidatePersonConditionComponent : Component
     /// Description will be applied if target gets SSDs.
     /// </summary>
     [DataField(required: true)]
-    public string? SSDDescription;
+    public string? CatatonicDescription; // SS220 rewrite: brings from handle ssd state to catatonic
 
     [DataField]
     public MindPool Pool = new AliveHumansPool();
@@ -52,5 +52,5 @@ public enum IntimidatePersonDescriptionType
 {
     Start = 0,
     Success,
-    SSD
+    Catatoinic, // SS220 rewrite: brings from handle ssd state to catatonic
 }

--- a/Content.Server/SS220/Objectives/Systems/IntimidatePersonConditionSystem.cs
+++ b/Content.Server/SS220/Objectives/Systems/IntimidatePersonConditionSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Objectives.Components;
 using Content.Server.Objectives.Systems;
 using Content.Server.SS220.Objectives.Components;
 using Content.Server.SS220.Trackers.Components;
+using Content.Shared.Mind.Components;
 using Content.Shared.Objectives.Components;
 using Content.Shared.Objectives.Systems;
 using Content.Shared.SSDIndicator;
@@ -37,12 +38,12 @@ public sealed partial class IntimidatePersonConditionSystem : EntitySystem
             return;
         }
 
-        //HandleSSDMoment
-        if (!TryComp<SSDIndicatorComponent>(entity.Comp.TargetMob, out var ssdIndicator)
-            || ssdIndicator.IsSSD)
+        //SS220 rewrite: brings from handle ssd state to catatonic
+        if (!TryComp<MindExaminableComponent>(entity.Comp.TargetMob, out var mindExaminable)
+            || mindExaminable.State == MindState.Catatonic)
         {
             args.Progress = 1f;
-            SetDescription(entity, IntimidatePersonDescriptionType.SSD);
+            SetDescription(entity, IntimidatePersonDescriptionType.Catatoinic);
             return;
         }
 
@@ -112,7 +113,7 @@ public sealed partial class IntimidatePersonConditionSystem : EntitySystem
         {
             IntimidatePersonDescriptionType.Start => component.StartDescription,
             IntimidatePersonDescriptionType.Success => component.SuccessDescription,
-            IntimidatePersonDescriptionType.SSD => component.SSDDescription,
+            IntimidatePersonDescriptionType.Catatoinic => component.CatatonicDescription,
             _ => null
         };
 

--- a/Content.Server/SS220/Objectives/Systems/IntimidatePersonConditionSystem.cs
+++ b/Content.Server/SS220/Objectives/Systems/IntimidatePersonConditionSystem.cs
@@ -38,7 +38,6 @@ public sealed partial class IntimidatePersonConditionSystem : EntitySystem
             return;
         }
 
-        //SS220 rewrite: brings from handle ssd state to catatonic
         if (!TryComp<MindExaminableComponent>(entity.Comp.TargetMob, out var mindExaminable)
             || mindExaminable.State == MindState.Catatonic)
         {

--- a/Resources/Locale/ru-RU/ss220/objectives/ninja.ftl
+++ b/Resources/Locale/ru-RU/ss220/objectives/ninja.ftl
@@ -4,17 +4,17 @@ ent-NinjaFrameTargetObjective = Подставить цель
 
 objective-condition-intimidate-target-brute-title = Заказ на запугивание { $targetName }, в должности { CAPITALIZE($job) }.
 objective-condition-intimidate-target-brute-desc = Вам заказали преподать урок члену экипажа станции. Избейте вашу цель несколько раз, пока она в ясном сознании.
-objective-condition-intimidate-target-brute-desc-ssd= Цель впала в ССД, такой исход тоже возможен.
+objective-condition-intimidate-target-brute-desc-catatonic= Цель впала в кататонический ступор, такой исход тоже возможен.
 objective-condition-intimidate-target-brute-desc-success = Вы успешно преподали урок.
 
 objective-condition-intimidate-target-burn-title = Заказ на запугивание { $targetName }, в должности { CAPITALIZE($job) }.
 objective-condition-intimidate-target-burn-desc = Вам заказали преподать урок члену экипажа станции. Нанесите вашей цели достаточно ожогов, пока она в ясном сознании.
-objective-condition-intimidate-target-burn-desc-ssd= Цель впала в ССД, такой исход тоже возможен.
+objective-condition-intimidate-target-burn-desc-catatonic= Цель впала в кататонический ступор, такой исход тоже возможен.
 objective-condition-intimidate-target-burn-desc-success = Вы успешно преподали урок.
 
 objective-condition-intimidate-target-toxin-title = Заказ на запугивание { $targetName }, в должности { CAPITALIZE($job) }.
 objective-condition-intimidate-target-toxin-desc = Вам заказали преподать урок члену экипажа станции. Отравите вашу цель несколько раз, пока она в ясном сознании.
-objective-condition-intimidate-target-toxin-desc-ssd= Цель впала в ССД, такой исход тоже возможен.
+objective-condition-intimidate-target-toxin-desc-catatonic= Цель впала в кататонический ступор, такой исход тоже возможен.
 objective-condition-intimidate-target-toxin-desc-success = Вы успешно преподали урок.
 
 ent-LeaveNoTraceObjective = Не раскрывайте себя

--- a/Resources/Prototypes/SS220/Objectives/ninja.yml
+++ b/Resources/Prototypes/SS220/Objectives/ninja.yml
@@ -35,7 +35,7 @@
   - type: IntimidatePersonCondition
     startDescription: objective-condition-intimidate-target-brute-desc
     successDescription: objective-condition-intimidate-target-brute-desc-success
-    sSDDescription: objective-condition-intimidate-target-brute-desc-ssd
+    catatonicDescription: objective-condition-intimidate-target-brute-desc-catatonic
     damageTrackerSpecifier:
       damageGroup: Brute
       allowedState: [Alive]
@@ -54,7 +54,7 @@
   - type: IntimidatePersonCondition
     startDescription: objective-condition-intimidate-target-burn-desc
     successDescription: objective-condition-intimidate-target-burn-desc-success
-    sSDDescription: objective-condition-intimidate-target-burn-desc-ssd
+    catatonicDescription: objective-condition-intimidate-target-burn-desc-catatonic
     damageTrackerSpecifier:
       damageGroup: Burn
       allowedState: [Alive]
@@ -73,7 +73,7 @@
   - type: IntimidatePersonCondition
     startDescription: objective-condition-intimidate-target-toxin-desc
     successDescription: objective-condition-intimidate-target-toxin-desc-success
-    sSDDescription: objective-condition-intimidate-target-toxin-desc-ssd
+    catatonicDescription: objective-condition-intimidate-target-toxin-desc-catatonic
     filter:
     - !type:SpeciesMindFilter
       species:

--- a/Resources/Prototypes/SS220/Objectives/traitor.yml
+++ b/Resources/Prototypes/SS220/Objectives/traitor.yml
@@ -72,7 +72,7 @@
   - type: IntimidatePersonCondition
     startDescription: objective-condition-intimidate-target-brute-desc
     successDescription: objective-condition-intimidate-target-brute-desc-success
-    sSDDescription: objective-condition-intimidate-target-brute-desc-ssd
+    catatonicDescription: objective-condition-intimidate-target-brute-desc-catatonic
     damageTrackerSpecifier:
       damageGroup: Brute
       allowedState: [Alive]
@@ -91,7 +91,7 @@
   - type: IntimidatePersonCondition
     startDescription: objective-condition-intimidate-target-burn-desc
     successDescription: objective-condition-intimidate-target-burn-desc-success
-    sSDDescription: objective-condition-intimidate-target-burn-desc-ssd
+    catatonicDescription: objective-condition-intimidate-target-burn-desc-catatonic
     damageTrackerSpecifier:
       damageGroup: Burn
       allowedState: [Alive]
@@ -110,7 +110,7 @@
   - type: IntimidatePersonCondition
     startDescription: objective-condition-intimidate-target-toxin-desc
     successDescription: objective-condition-intimidate-target-toxin-desc-success
-    sSDDescription: objective-condition-intimidate-target-toxin-desc-ssd
+    catatonicDescription: objective-condition-intimidate-target-toxin-desc-catatonic
     filter:
     - !type:SpeciesMindFilter
       species:


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->

Переделывает захват на кататонический ступор вместо SSD при цели на нанесении побоев/кражи/токсинов.

fixes https://github.com/SerbiaStrong-220/space-station-14/issues/4519

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру и опубликован на Discord-сервере после принятия вашего PR.

В список изменений следует помещать только то, что действительно важно игрокам.

В списке изменений обязательно должен присутствовать символ :cl:, чтобы бот распознал изменения.

Вы можете указать своё имя после символа :cl:, именно оно будет отображаться в игровом списке изменений (если имя не указано, бот возьмёт ваш логин на GitHub).  
Например: :cl: Ian

В списке изменений тип значка не является частью предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров
-->

:cl: AlanWake
- fix: Исправление цели на запугивание: теперь цель должна оказаться в кататоническом ступоре, вместо SSD, для её засчитывания!
