### PR TITLE
[FIX] PointLightComponent inside slime doesn't change state after leaving an entity-container

### DIFF
--- a/Resources/Prototypes/Body/Species/slime.yml
+++ b/Resources/Prototypes/Body/Species/slime.yml
@@ -109,6 +109,7 @@
     containers:
       storagebase: !type:Container
         ents: []
+        occludes: False # SS220-fixslimeflashlight
   - type: UserInterface
     interfaces:
       enum.StorageUiKey.Key:


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
После выхода из контейнера, фонарик внутри слайма оставался потухшим (хотя заходил он с зажжённым и его state оставался во включённом состоянии).

fixes https://github.com/SerbiaStrong-220/space-station-14/issues/4003

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру и опубликован на Discord-сервере после принятия вашего PR.

В список изменений следует помещать только то, что действительно важно игрокам.

В списке изменений обязательно должен присутствовать символ :cl:, чтобы бот распознал изменения.

Вы можете указать своё имя после символа :cl:, именно оно будет отображаться в игровом списке изменений (если имя не указано, бот возьмёт ваш логин на GitHub).  
Например: :cl: Ian

В списке изменений тип значка не является частью предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров
-->

:cl: Alan Wake
- fix: Исправлены фонарики внутри слаймолюдей!