### PR TITLE
[MIT] ADD: Storage Clothing Blocker

### DIFF
--- a/Content.Shared/SS220/StorageClothingBlocker/StorageClothingBlockerComponent.cs
+++ b/Content.Shared/SS220/StorageClothingBlocker/StorageClothingBlockerComponent.cs
@@ -1,0 +1,14 @@
+// © SS220, MIT full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/MIT_LICENSE.TXT
+
+using Content.Shared.Inventory;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.SS220.StorageClothingBlocker;
+
+[RegisterComponent]
+[NetworkedComponent]
+public sealed partial class StorageClothingBlockerComponent : Component
+{
+    [DataField]
+    public SlotFlags SlotFlags = SlotFlags.INNERCLOTHING;
+}

--- a/Content.Shared/SS220/StorageClothingBlocker/StorageClothingBlockerComponent.cs
+++ b/Content.Shared/SS220/StorageClothingBlocker/StorageClothingBlockerComponent.cs
@@ -10,5 +10,5 @@ namespace Content.Shared.SS220.StorageClothingBlocker;
 public sealed partial class StorageClothingBlockerComponent : Component
 {
     [DataField]
-    public SlotFlags SlotFlags = SlotFlags.INNERCLOTHING;
+    public SlotFlags SlotFlags = SlotFlags.TORSO;
 }

--- a/Content.Shared/SS220/StorageClothingBlocker/StorageClothingBlockerSystem.cs
+++ b/Content.Shared/SS220/StorageClothingBlocker/StorageClothingBlockerSystem.cs
@@ -1,0 +1,55 @@
+// © SS220, MIT full text: https://raw.githubusercontent.com/SerbiaStrong-220/space-station-14/master/MIT_LICENSE.TXT
+
+using System.Linq;
+using Content.Shared.Interaction.Components;
+using Content.Shared.Inventory;
+using Content.Shared.Inventory.Events;
+using Content.Shared.Storage;
+
+namespace Content.Shared.SS220.StorageClothingBlocker;
+
+public sealed partial class StorageClothingBlockerSystem : EntitySystem
+{
+    [Dependency] private InventorySystem _inventory = default!;
+    [Dependency] private SharedUserInterfaceSystem _ui = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<StorageClothingBlockerComponent, StorageInteractAttemptEvent>(OnInteractAttempt);
+        SubscribeLocalEvent<StorageClothingBlockerComponent, DidEquipEvent>(OnGotEquipped);
+    }
+
+    private void OnInteractAttempt(Entity<StorageClothingBlockerComponent> ent, ref StorageInteractAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        var enumerator = _inventory.GetSlotEnumerator(ent.Owner, ent.Comp.SlotFlags);
+        if (enumerator.NextItem(out _) && args.User != ent.Owner)
+            args.Cancelled = true;
+    }
+
+    private void OnGotEquipped(Entity<StorageClothingBlockerComponent> ent, ref DidEquipEvent args)
+    {
+        if (args.EquipTarget != ent.Owner)
+            return;
+
+        if ((args.SlotFlags & ent.Comp.SlotFlags) != SlotFlags.NONE)
+            RemoveAllViewers(ent.Owner);
+    }
+
+    private void RemoveAllViewers(EntityUid storage)
+    {
+        var actors = _ui.GetActors(storage, StorageComponent.StorageUiKey.Key).ToList();
+        foreach (var actor in actors)
+        {
+            if (actor == storage)
+                continue;
+
+            if (HasComp<BypassInteractionChecksComponent>(actor))
+                continue;
+
+            _ui.CloseUi(storage, StorageComponent.StorageUiKey.Key, actor);
+        }
+    }
+}

--- a/Resources/Prototypes/Body/Species/slime.yml
+++ b/Resources/Prototypes/Body/Species/slime.yml
@@ -98,6 +98,9 @@
         layer:
         - MobLayer
 # SS220-change-races-height end
+  # SS220 add storage clothing blocker start
+  - type: StorageClothingBlocker
+  # SS220 add storage clothing blocker end
   - type: Storage
     clickInsert: false
     grid:


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
(close: https://github.com/SerbiaStrong-220/DevTeam220/issues/840)

Добавлен компонент, который блокирует взаимодействие с хранилищем, если на сущности надет какой-то предмет в какой-то определенный слот

Верхняя одежда теперь блокирует доступ сторонних сущностей к внутреннему хранилищу слаймолюда.

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl: ReeZii
- add: Верхняя одежда теперь блокирует доступ сторонних сущностей к внутреннему хранилищу слаймолюда.