### PR TITLE
Night vision~

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2039,6 +2039,7 @@
       behaviors:
       - !type:GibBehavior
         recursive: false
+  - type: ScotopicVision #SS220-NightVision
 
 - type: entity
   parent: MobMouse
@@ -2771,6 +2772,10 @@
 #        settings: short
 # SS220-partial-revert-reffle-End
     - type: GhostTakeoverAvailable
+    #SS220-NightVision-BGN
+    - type: ScotopicVision
+      energy: 0.36
+    #SS220-NightVision-END
 
 - type: entity
   name: tarantula

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -90,6 +90,10 @@
       interactFailureString: petting-failure-carp
       interactFailureSound:
         path: /Audio/Effects/bite.ogg
+    #SS220-NightVision-BGN
+    - type: ScotopicVision
+      energy: 0.48
+    #SS220-NightVision-END
 
 - type: entity
   parent: BaseMobCarp

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -153,6 +153,10 @@
   - type: TTS
     voice: hagraven
   #SS220-AddTTSRatKing end
+  #SS220-NightVision-BGN
+  - type: ScotopicVision
+    energy: 0.48
+  #SS220-NightVision-END
 
 - type: entity
   id: MobRatKingBuff
@@ -335,6 +339,10 @@
   - type: FireVisuals
     sprite: Mobs/Effects/onfire.rsi
     normalState: Mouse_burning
+  #SS220-NightVision-BGN
+  - type: ScotopicVision
+    energy: 0.48
+  #SS220-NightVision-END
 
 - type: entityTable
   id: RatKingLoot

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -70,6 +70,10 @@
   - type: GhostTakeoverAvailable
   - type: Speech
     speechVerb: LargeMob
+  #SS220-NightVision-BGN
+  - type: ScotopicVision
+    energy: 0.48
+  #SS220-NightVision-END
 
 - type: entity
   name: space bear

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -193,6 +193,10 @@
     speedModifier: 2.5 # fast because dragon strong
     useSound:
       path: /Audio/Items/crowbar.ogg
+  #SS220-NightVision-BGN
+  - type: ScotopicVision
+    energy: 0.48
+  #SS220-NightVision-END
 
 - type: entity
   parent: BaseMobDragon

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -298,6 +298,10 @@
         highSensitiveVisionRadius: 4
         state: half
       # SS220 Ninja Keen-Hearing-end
+      #SS220-NightVision-BGN
+      - type: ScotopicVision
+        energy: 1
+      #SS220-NightVision-END
       # SS220-add-ninja-thieving-begin
       - type: Thieving
         stripTimeReduction: 2

--- a/Resources/Prototypes/SS220/DemonRofler/mob.yml
+++ b/Resources/Prototypes/SS220/DemonRofler/mob.yml
@@ -44,6 +44,8 @@
     description: ghost-role-information-dark-reaper-description
     rules: ghost-role-information-dark-reaper-rules
     job: DarkReaper
+  - type: ScotopicVision
+    energy: 0.48
 
   # Visuals and appearance
   - type: Sprite

--- a/Resources/Prototypes/SS220/Entities/Mobs/NPCs/spider_queen.yml
+++ b/Resources/Prototypes/SS220/Entities/Mobs/NPCs/spider_queen.yml
@@ -131,6 +131,9 @@
     telepathyChannelPrototype: TelepathyChannelHive
   - type: FlashImmunity
   - type: Lifesteal
+  - type: ScotopicVision
+    radius: 8
+    energy: 0.48
 
 - type: entity
   parent: BaseMobSpiderQueen


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
ПР от Ризи всё не выходит, а Неро развивает свою тему, а я что? Я люблю баффать не СБ-Синди-Культ 👀

А если серьёзно, очевидно, что цель изменений - это QoL, а не трогать баланс. Большинство затронутых сущностей большую часть времени проводят в темноте. Например, улью термовидение никак не помогает, дракону приходится жрать всё подряд вслепую, а ниндзе ~~сварку включать и смотреть~~ я добавил фонарик в шлем.

Значение 0.48 выбрано методом тыка. Если брать ближе к единице, то сущность становится фонариком, если ближе к текущему (0,12), то субъективно слабовато.

К очкам компонент не прикрепить, поэтому сам ниндзя будет иметь ночное зрение, а не его снаряжение.

**Медиа**


<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl: Kemran
- add: Добавлено ночное зрение следующим существам: улью пауков, всем драконам, всем карпам, жнецу, ниндзя, королю крыс и его слугам, космической фауне, обычной агрессивной фауне (несколько слабее; слаймы обделены), а также мышам (слабее, чем у таяран).
