### PR TITLE
Fix GhostRolesRui centered

### DIFF
--- a/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
@@ -94,7 +94,10 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
             if (state is not GhostRolesEuiState ghostState)
                 return;
 
-            _window.OpenCentered(); // ss220 add verb for ghost role
+            // ss220 add verb for ghost role start
+            if (!_window.IsOpen)
+                _window.OpenCentered();
+            // ss220 add verb for ghost role end
 
             // We must save BodyVisible state, so all Collapsible boxes will not close
             // on adding new ghost role.


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
В ПРе [ADD: Verb for Ghost Roles](https://github.com/SerbiaStrong-220/space-station-14/pull/4414/changes#top) вызов центрирования окна (`_window.OpenCentered();`) перенесли из метода `Opened()` в `HandleState()`, из-за чего окно выбора гостевых ролей центрируется при каждом получении нового состояния от сервера на клиенте. Убрать вызов `_window.OpenCentered()` из `HandleState()` нельзя, тогда окно вообще не появляется перед игроком. Просто вернуть `_window.OpenCentered()` в `Opened()` тоже нельзя, тогда при использовании вёрба запроса гост роли открывается новое пустое окно выбора гост роли.

Начал искать вызовы `_window.OpenCentered()`, может быть, кто-то ранее сталкивался с подобной проблемой. Нашёлся единственный вызов вне методов `Open()` в `AHelpUIController.cs`, где перед toggle проверяется состояние окна через `_window!.IsOpen`. Добавил проверку `if (!_window.IsOpen)`. Теперь, по идее, `HandleState()` не открывает окно повторно, если оно уже открыто.
_P.S. Не знаю, нужен ли оператор `!` внутри моего `if (!_window.IsOpen)`. Он без него._

Вроде всё проверил, не центрирует окно, верб запроса также работает нормально.

fix: https://github.com/SerbiaStrong-220/space-station-14/issues/4556

<!--CLIgnore-->

<img width="633" height="460" alt="image" src="https://github.com/user-attachments/assets/ad9e1ea3-98af-468f-aeab-32fcfbadd76c" />


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**
:cl: Kemran
- fix: Исправлен баг с центрированием окна "Роли призраков" при каждом обновлении гост ролей.
