### PR TITLE
No Dark Reaper on lowpop

### DIFF
--- a/Resources/Prototypes/SS220/GameRules/midround_antags.yml
+++ b/Resources/Prototypes/SS220/GameRules/midround_antags.yml
@@ -8,7 +8,7 @@
     weight: 7.5
     duration: 1
     earliestStart: 45
-    minimumPlayers: 30
+    minimumPlayers: 45
   - type: AntagSelection
     definitions:
     - spawnerPrototype: SpawnPointGhostDarkReaperRune
@@ -24,7 +24,7 @@
   categories: [ GameRules ]
   components:
   - type: GameRule
-    minPlayers: 30
+    minPlayers: 45
   - type: AntagSelection
     selectionTime: PrePlayerSpawn
     definitions:

--- a/Resources/Prototypes/SS220/game_presets.yml
+++ b/Resources/Prototypes/SS220/game_presets.yml
@@ -6,7 +6,7 @@
   name: roles-antag-darkreaper-name
   description: darkreaper-preset-description
   showInVote: false
-  minPlayers: 30
+  minPlayers: 45
   rules:
     - DarkReaperSpawnMajor
     - BasicStationEventScheduler


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Лучший антаг всея 220 не работает на лоу-мидпопе. 
Я вижу одну и туже картину уже несколько недель. Появляется жнец на 30-35 душ. В бриге человек 5. Жнец быстро отжирается до второй фазы на каргонцах/инжах/агентах в техах. Далее, если экипаж не успевают в кротчайшие сроки согнать в один отдел, то жнец начинает планомерно их зачищать. Если экипаж сгонят в один отдел, то жнец будет вылезать в нем, давать крик, танчить определенное кол-во урона, хилясь об лежащий мирняк и уходит на отхил об животину. Единственный сценарий в таком случае, от которого жнец помрет, это удачное попадание во время резни в меде или засада.
Ну и сами засады. Прекрасный геймплей в с сидением 10 минут к ряду в выключенной мусорке, ожидая, когда жнец выйдет на жертву.

Онлайн для ролла режима повышен до 45, где экипажа будет больше (как и шансов на победу)

**Медиа**

<!--CLIgnore-->
**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я **ознакомился** с [наставлениями по работе с репозиторием](https://serbiastrong-220.github.io/ss220-docs/development/ss220-guidelines/) и следовал им при создании PR'а.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
<!--/CLIgnore-->

**Изменения**

:cl:
- tweak: Изменено необходимое количество игроков для события спавна жнеца с 30 до 45